### PR TITLE
add server_info ffi for TiFlash

### DIFF
--- a/components/raftstore/src/engine_store_ffi/interfaces.rs
+++ b/components/raftstore/src/engine_store_ffi/interfaces.rs
@@ -2,281 +2,358 @@
 
 #[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
-    #[repr(C)]
-    pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
-    impl<T> __BindgenUnionField<T> {
-        #[inline]
-        pub const fn new() -> Self {
-            __BindgenUnionField(::std::marker::PhantomData)
-        }
-        #[inline]
-        pub unsafe fn as_ref(&self) -> &T {
-            ::std::mem::transmute(self)
-        }
-        #[inline]
-        pub unsafe fn as_mut(&mut self) -> &mut T {
-            ::std::mem::transmute(self)
-        }
-    }
-    impl<T> ::std::default::Default for __BindgenUnionField<T> {
-        #[inline]
-        fn default() -> Self {
-            Self::new()
-        }
-    }
-    impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
-        #[inline]
-        fn clone(&self) -> Self {
-            Self::new()
-        }
-    }
-    impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
-    impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-        fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-            fmt.write_str("__BindgenUnionField")
-        }
-    }
-    impl<T> ::std::hash::Hash for __BindgenUnionField<T> {
-        fn hash<H: ::std::hash::Hasher>(&self, _state: &mut H) {}
-    }
-    impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
-        fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-            true
-        }
-    }
-    impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
     #[allow(unused_imports)]
     use self::super::root;
-    pub const _LIBCPP_HAS_MERGED_TYPEINFO_NAMES_DEFAULT: u32 = 1;
-    pub const _LIBCPP_VERSION: u32 = 10000;
-    pub const _LIBCPP_ABI_VERSION: u32 = 1;
-    pub const _LIBCPP_STD_VER: u32 = 11;
-    pub const _LIBCPP_OBJECT_FORMAT_MACHO: u32 = 1;
-    pub const _LIBCPP_HIDE_FROM_ABI_PER_TU: u32 = 1;
-    pub const _LIBCPP_DEBUG_LEVEL: u32 = 0;
-    pub const _LIBCPP_LOCALE__L_EXTENSIONS: u32 = 1;
-    pub const _LIBCPP_HAS_CATOPEN: u32 = 1;
-    pub const __STDCPP_THREADS__: u32 = 1;
+    pub const _GLIBCXX_CSTDINT: u32 = 1;
+    pub const _GLIBCXX_CXX_CONFIG_H: u32 = 1;
+    pub const _GLIBCXX_RELEASE: u32 = 7;
+    pub const __GLIBCXX__: u32 = 20180125;
+    pub const _GLIBCXX_HAVE_ATTRIBUTE_VISIBILITY: u32 = 1;
+    pub const _GLIBCXX_USE_DEPRECATED: u32 = 1;
+    pub const _GLIBCXX_EXTERN_TEMPLATE: u32 = 1;
+    pub const _GLIBCXX_USE_DUAL_ABI: u32 = 1;
+    pub const _GLIBCXX_USE_CXX11_ABI: u32 = 1;
+    pub const _GLIBCXX_INLINE_VERSION: u32 = 0;
+    pub const _GLIBCXX_USE_ALLOCATOR_NEW: u32 = 1;
+    pub const _GLIBCXX_OS_DEFINES: u32 = 1;
+    pub const __NO_CTYPE: u32 = 1;
+    pub const _FEATURES_H: u32 = 1;
+    pub const __USE_ANSI: u32 = 1;
+    pub const _ISOC95_SOURCE: u32 = 1;
+    pub const _ISOC99_SOURCE: u32 = 1;
+    pub const _ISOC11_SOURCE: u32 = 1;
+    pub const _POSIX_SOURCE: u32 = 1;
+    pub const _POSIX_C_SOURCE: u32 = 200809;
+    pub const _XOPEN_SOURCE: u32 = 700;
+    pub const _XOPEN_SOURCE_EXTENDED: u32 = 1;
+    pub const _LARGEFILE64_SOURCE: u32 = 1;
+    pub const _BSD_SOURCE: u32 = 1;
+    pub const _SVID_SOURCE: u32 = 1;
+    pub const _ATFILE_SOURCE: u32 = 1;
+    pub const __USE_ISOC11: u32 = 1;
+    pub const __USE_ISOC99: u32 = 1;
+    pub const __USE_ISOC95: u32 = 1;
+    pub const __USE_ISOCXX11: u32 = 1;
+    pub const __USE_POSIX: u32 = 1;
+    pub const __USE_POSIX2: u32 = 1;
+    pub const __USE_POSIX199309: u32 = 1;
+    pub const __USE_POSIX199506: u32 = 1;
+    pub const __USE_XOPEN2K: u32 = 1;
+    pub const __USE_XOPEN2K8: u32 = 1;
+    pub const __USE_XOPEN: u32 = 1;
+    pub const __USE_XOPEN_EXTENDED: u32 = 1;
+    pub const __USE_UNIX98: u32 = 1;
+    pub const _LARGEFILE_SOURCE: u32 = 1;
+    pub const __USE_XOPEN2K8XSI: u32 = 1;
+    pub const __USE_XOPEN2KXSI: u32 = 1;
+    pub const __USE_LARGEFILE: u32 = 1;
+    pub const __USE_LARGEFILE64: u32 = 1;
+    pub const __USE_MISC: u32 = 1;
+    pub const __USE_BSD: u32 = 1;
+    pub const __USE_SVID: u32 = 1;
+    pub const __USE_ATFILE: u32 = 1;
+    pub const __USE_GNU: u32 = 1;
+    pub const __USE_FORTIFY_LEVEL: u32 = 0;
+    pub const _STDC_PREDEF_H: u32 = 1;
+    pub const __STDC_IEC_559__: u32 = 1;
+    pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+    pub const __STDC_ISO_10646__: u32 = 201103;
+    pub const __STDC_NO_THREADS__: u32 = 1;
+    pub const __GNU_LIBRARY__: u32 = 6;
+    pub const __GLIBC__: u32 = 2;
+    pub const __GLIBC_MINOR__: u32 = 17;
+    pub const __GLIBC_HAVE_LONG_LONG: u32 = 1;
+    pub const _SYS_CDEFS_H: u32 = 1;
     pub const __WORDSIZE: u32 = 64;
-    pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
-    pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
-    pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-    pub const __DARWIN_UNIX03: u32 = 1;
-    pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-    pub const __DARWIN_VERS_1050: u32 = 1;
-    pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-    pub const __DARWIN_SUF_64_BIT_INO_T: &'static [u8; 9usize] = b"$INODE64\0";
-    pub const __DARWIN_SUF_1050: &'static [u8; 6usize] = b"$1050\0";
-    pub const __DARWIN_SUF_EXTSN: &'static [u8; 14usize] = b"$DARWIN_EXTSN\0";
-    pub const __DARWIN_C_ANSI: u32 = 4096;
-    pub const __DARWIN_C_FULL: u32 = 900000;
-    pub const __DARWIN_C_LEVEL: u32 = 900000;
-    pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-    pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-    pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-    pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-    pub const __PTHREAD_SIZE__: u32 = 8176;
-    pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-    pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-    pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-    pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-    pub const __PTHREAD_COND_SIZE__: u32 = 40;
-    pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-    pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-    pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-    pub const INT8_MAX: u32 = 127;
-    pub const INT16_MAX: u32 = 32767;
-    pub const INT32_MAX: u32 = 2147483647;
-    pub const INT64_MAX: u64 = 9223372036854775807;
+    pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+    pub const __SYSCALL_WORDSIZE: u32 = 64;
+    pub const _GLIBCXX_CPU_DEFINES: u32 = 1;
+    pub const _GLIBCXX_FAST_MATH: u32 = 0;
+    pub const _GLIBCXX_HAVE_ACOSF: u32 = 1;
+    pub const _GLIBCXX_HAVE_ACOSL: u32 = 1;
+    pub const _GLIBCXX_HAVE_ALIGNED_ALLOC: u32 = 1;
+    pub const _GLIBCXX_HAVE_ASINF: u32 = 1;
+    pub const _GLIBCXX_HAVE_ASINL: u32 = 1;
+    pub const _GLIBCXX_HAVE_AS_SYMVER_DIRECTIVE: u32 = 1;
+    pub const _GLIBCXX_HAVE_ATAN2F: u32 = 1;
+    pub const _GLIBCXX_HAVE_ATAN2L: u32 = 1;
+    pub const _GLIBCXX_HAVE_ATANF: u32 = 1;
+    pub const _GLIBCXX_HAVE_ATANL: u32 = 1;
+    pub const _GLIBCXX_HAVE_AT_QUICK_EXIT: u32 = 1;
+    pub const _GLIBCXX_HAVE_CEILF: u32 = 1;
+    pub const _GLIBCXX_HAVE_CEILL: u32 = 1;
+    pub const _GLIBCXX_HAVE_COMPLEX_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_COSF: u32 = 1;
+    pub const _GLIBCXX_HAVE_COSHF: u32 = 1;
+    pub const _GLIBCXX_HAVE_COSHL: u32 = 1;
+    pub const _GLIBCXX_HAVE_COSL: u32 = 1;
+    pub const _GLIBCXX_HAVE_DIRENT_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_DLFCN_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_EBADMSG: u32 = 1;
+    pub const _GLIBCXX_HAVE_ECANCELED: u32 = 1;
+    pub const _GLIBCXX_HAVE_ECHILD: u32 = 1;
+    pub const _GLIBCXX_HAVE_EIDRM: u32 = 1;
+    pub const _GLIBCXX_HAVE_ENDIAN_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_ENODATA: u32 = 1;
+    pub const _GLIBCXX_HAVE_ENOLINK: u32 = 1;
+    pub const _GLIBCXX_HAVE_ENOSPC: u32 = 1;
+    pub const _GLIBCXX_HAVE_ENOSR: u32 = 1;
+    pub const _GLIBCXX_HAVE_ENOSTR: u32 = 1;
+    pub const _GLIBCXX_HAVE_ENOTRECOVERABLE: u32 = 1;
+    pub const _GLIBCXX_HAVE_ENOTSUP: u32 = 1;
+    pub const _GLIBCXX_HAVE_EOVERFLOW: u32 = 1;
+    pub const _GLIBCXX_HAVE_EOWNERDEAD: u32 = 1;
+    pub const _GLIBCXX_HAVE_EPERM: u32 = 1;
+    pub const _GLIBCXX_HAVE_EPROTO: u32 = 1;
+    pub const _GLIBCXX_HAVE_ETIME: u32 = 1;
+    pub const _GLIBCXX_HAVE_ETIMEDOUT: u32 = 1;
+    pub const _GLIBCXX_HAVE_ETXTBSY: u32 = 1;
+    pub const _GLIBCXX_HAVE_EWOULDBLOCK: u32 = 1;
+    pub const _GLIBCXX_HAVE_EXCEPTION_PTR_SINCE_GCC46: u32 = 1;
+    pub const _GLIBCXX_HAVE_EXECINFO_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_EXPF: u32 = 1;
+    pub const _GLIBCXX_HAVE_EXPL: u32 = 1;
+    pub const _GLIBCXX_HAVE_FABSF: u32 = 1;
+    pub const _GLIBCXX_HAVE_FABSL: u32 = 1;
+    pub const _GLIBCXX_HAVE_FCNTL_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_FENV_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_FINITE: u32 = 1;
+    pub const _GLIBCXX_HAVE_FINITEF: u32 = 1;
+    pub const _GLIBCXX_HAVE_FINITEL: u32 = 1;
+    pub const _GLIBCXX_HAVE_FLOAT_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_FLOORF: u32 = 1;
+    pub const _GLIBCXX_HAVE_FLOORL: u32 = 1;
+    pub const _GLIBCXX_HAVE_FMODF: u32 = 1;
+    pub const _GLIBCXX_HAVE_FMODL: u32 = 1;
+    pub const _GLIBCXX_HAVE_FREXPF: u32 = 1;
+    pub const _GLIBCXX_HAVE_FREXPL: u32 = 1;
+    pub const _GLIBCXX_HAVE_GETIPINFO: u32 = 1;
+    pub const _GLIBCXX_HAVE_GETS: u32 = 1;
+    pub const _GLIBCXX_HAVE_HYPOT: u32 = 1;
+    pub const _GLIBCXX_HAVE_HYPOTF: u32 = 1;
+    pub const _GLIBCXX_HAVE_HYPOTL: u32 = 1;
+    pub const _GLIBCXX_HAVE_ICONV: u32 = 1;
+    pub const _GLIBCXX_HAVE_INT64_T: u32 = 1;
+    pub const _GLIBCXX_HAVE_INT64_T_LONG: u32 = 1;
+    pub const _GLIBCXX_HAVE_INTTYPES_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_ISINF: u32 = 1;
+    pub const _GLIBCXX_HAVE_ISINFF: u32 = 1;
+    pub const _GLIBCXX_HAVE_ISINFL: u32 = 1;
+    pub const _GLIBCXX_HAVE_ISNAN: u32 = 1;
+    pub const _GLIBCXX_HAVE_ISNANF: u32 = 1;
+    pub const _GLIBCXX_HAVE_ISNANL: u32 = 1;
+    pub const _GLIBCXX_HAVE_ISWBLANK: u32 = 1;
+    pub const _GLIBCXX_HAVE_LC_MESSAGES: u32 = 1;
+    pub const _GLIBCXX_HAVE_LDEXPF: u32 = 1;
+    pub const _GLIBCXX_HAVE_LDEXPL: u32 = 1;
+    pub const _GLIBCXX_HAVE_LIBINTL_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_LIMIT_AS: u32 = 1;
+    pub const _GLIBCXX_HAVE_LIMIT_DATA: u32 = 1;
+    pub const _GLIBCXX_HAVE_LIMIT_FSIZE: u32 = 1;
+    pub const _GLIBCXX_HAVE_LIMIT_RSS: u32 = 1;
+    pub const _GLIBCXX_HAVE_LIMIT_VMEM: u32 = 0;
+    pub const _GLIBCXX_HAVE_LINUX_FUTEX: u32 = 1;
+    pub const _GLIBCXX_HAVE_LOCALE_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_LOG10F: u32 = 1;
+    pub const _GLIBCXX_HAVE_LOG10L: u32 = 1;
+    pub const _GLIBCXX_HAVE_LOGF: u32 = 1;
+    pub const _GLIBCXX_HAVE_LOGL: u32 = 1;
+    pub const _GLIBCXX_HAVE_MBSTATE_T: u32 = 1;
+    pub const _GLIBCXX_HAVE_MEMALIGN: u32 = 1;
+    pub const _GLIBCXX_HAVE_MEMORY_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_MODF: u32 = 1;
+    pub const _GLIBCXX_HAVE_MODFF: u32 = 1;
+    pub const _GLIBCXX_HAVE_MODFL: u32 = 1;
+    pub const _GLIBCXX_HAVE_OBSOLETE_ISINF: u32 = 1;
+    pub const _GLIBCXX_HAVE_OBSOLETE_ISNAN: u32 = 1;
+    pub const _GLIBCXX_HAVE_POLL: u32 = 1;
+    pub const _GLIBCXX_HAVE_POSIX_MEMALIGN: u32 = 1;
+    pub const _GLIBCXX_HAVE_POWF: u32 = 1;
+    pub const _GLIBCXX_HAVE_POWL: u32 = 1;
+    pub const _GLIBCXX_HAVE_QUICK_EXIT: u32 = 1;
+    pub const _GLIBCXX_HAVE_SETENV: u32 = 1;
+    pub const _GLIBCXX_HAVE_SINCOS: u32 = 1;
+    pub const _GLIBCXX_HAVE_SINCOSF: u32 = 1;
+    pub const _GLIBCXX_HAVE_SINCOSL: u32 = 1;
+    pub const _GLIBCXX_HAVE_SINF: u32 = 1;
+    pub const _GLIBCXX_HAVE_SINHF: u32 = 1;
+    pub const _GLIBCXX_HAVE_SINHL: u32 = 1;
+    pub const _GLIBCXX_HAVE_SINL: u32 = 1;
+    pub const _GLIBCXX_HAVE_SQRTF: u32 = 1;
+    pub const _GLIBCXX_HAVE_SQRTL: u32 = 1;
+    pub const _GLIBCXX_HAVE_STDALIGN_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_STDBOOL_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_STDINT_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_STDLIB_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_STRERROR_L: u32 = 1;
+    pub const _GLIBCXX_HAVE_STRERROR_R: u32 = 1;
+    pub const _GLIBCXX_HAVE_STRINGS_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_STRING_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_STRTOF: u32 = 1;
+    pub const _GLIBCXX_HAVE_STRTOLD: u32 = 1;
+    pub const _GLIBCXX_HAVE_STRUCT_DIRENT_D_TYPE: u32 = 1;
+    pub const _GLIBCXX_HAVE_STRXFRM_L: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYMVER_SYMBOL_RENAMING_RUNTIME_SUPPORT: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_IOCTL_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_IPC_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_PARAM_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_RESOURCE_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_SEM_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_STATVFS_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_STAT_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_SYSINFO_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_TIME_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_TYPES_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_UIO_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_S_ISREG: u32 = 1;
+    pub const _GLIBCXX_HAVE_TANF: u32 = 1;
+    pub const _GLIBCXX_HAVE_TANHF: u32 = 1;
+    pub const _GLIBCXX_HAVE_TANHL: u32 = 1;
+    pub const _GLIBCXX_HAVE_TANL: u32 = 1;
+    pub const _GLIBCXX_HAVE_TGMATH_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_TLS: u32 = 1;
+    pub const _GLIBCXX_HAVE_UCHAR_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_UNISTD_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_UTIME_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_VFWSCANF: u32 = 1;
+    pub const _GLIBCXX_HAVE_VSWSCANF: u32 = 1;
+    pub const _GLIBCXX_HAVE_VWSCANF: u32 = 1;
+    pub const _GLIBCXX_HAVE_WCHAR_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_WCSTOF: u32 = 1;
+    pub const _GLIBCXX_HAVE_WCTYPE_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_WRITEV: u32 = 1;
+    pub const LT_OBJDIR: &'static [u8; 7usize] = b".libs/\0";
+    pub const _GLIBCXX_PACKAGE_BUGREPORT: &'static [u8; 1usize] = b"\0";
+    pub const _GLIBCXX_PACKAGE_NAME: &'static [u8; 15usize] = b"package-unused\0";
+    pub const _GLIBCXX_PACKAGE_STRING: &'static [u8; 30usize] = b"package-unused version-unused\0";
+    pub const _GLIBCXX_PACKAGE_TARNAME: &'static [u8; 10usize] = b"libstdc++\0";
+    pub const _GLIBCXX_PACKAGE_URL: &'static [u8; 1usize] = b"\0";
+    pub const _GLIBCXX_PACKAGE__GLIBCXX_VERSION: &'static [u8; 15usize] = b"version-unused\0";
+    pub const STDC_HEADERS: u32 = 1;
+    pub const _GLIBCXX11_USE_C99_COMPLEX: u32 = 1;
+    pub const _GLIBCXX11_USE_C99_MATH: u32 = 1;
+    pub const _GLIBCXX11_USE_C99_STDIO: u32 = 1;
+    pub const _GLIBCXX11_USE_C99_STDLIB: u32 = 1;
+    pub const _GLIBCXX11_USE_C99_WCHAR: u32 = 1;
+    pub const _GLIBCXX98_USE_C99_COMPLEX: u32 = 1;
+    pub const _GLIBCXX98_USE_C99_MATH: u32 = 1;
+    pub const _GLIBCXX98_USE_C99_STDIO: u32 = 1;
+    pub const _GLIBCXX98_USE_C99_STDLIB: u32 = 1;
+    pub const _GLIBCXX98_USE_C99_WCHAR: u32 = 1;
+    pub const _GLIBCXX_ATOMIC_BUILTINS: u32 = 1;
+    pub const _GLIBCXX_FULLY_DYNAMIC_STRING: u32 = 0;
+    pub const _GLIBCXX_HAS_GTHREADS: u32 = 1;
+    pub const _GLIBCXX_HOSTED: u32 = 1;
+    pub const _GLIBCXX_RES_LIMITS: u32 = 1;
+    pub const _GLIBCXX_STDIO_EOF: i32 = -1;
+    pub const _GLIBCXX_STDIO_SEEK_CUR: u32 = 1;
+    pub const _GLIBCXX_STDIO_SEEK_END: u32 = 2;
+    pub const _GLIBCXX_SYMVER: u32 = 1;
+    pub const _GLIBCXX_SYMVER_GNU: u32 = 1;
+    pub const _GLIBCXX_USE_C11_UCHAR_CXX11: u32 = 1;
+    pub const _GLIBCXX_USE_C99: u32 = 1;
+    pub const _GLIBCXX_USE_C99_COMPLEX_TR1: u32 = 1;
+    pub const _GLIBCXX_USE_C99_CTYPE_TR1: u32 = 1;
+    pub const _GLIBCXX_USE_C99_FENV_TR1: u32 = 1;
+    pub const _GLIBCXX_USE_C99_INTTYPES_TR1: u32 = 1;
+    pub const _GLIBCXX_USE_C99_INTTYPES_WCHAR_T_TR1: u32 = 1;
+    pub const _GLIBCXX_USE_C99_MATH_TR1: u32 = 1;
+    pub const _GLIBCXX_USE_C99_STDINT_TR1: u32 = 1;
+    pub const _GLIBCXX_USE_CLOCK_MONOTONIC: u32 = 1;
+    pub const _GLIBCXX_USE_CLOCK_REALTIME: u32 = 1;
+    pub const _GLIBCXX_USE_DECIMAL_FLOAT: u32 = 1;
+    pub const _GLIBCXX_USE_FCHMOD: u32 = 1;
+    pub const _GLIBCXX_USE_FCHMODAT: u32 = 1;
+    pub const _GLIBCXX_USE_FLOAT128: u32 = 1;
+    pub const _GLIBCXX_USE_GETTIMEOFDAY: u32 = 1;
+    pub const _GLIBCXX_USE_GET_NPROCS: u32 = 1;
+    pub const _GLIBCXX_USE_INT128: u32 = 1;
+    pub const _GLIBCXX_USE_LFS: u32 = 1;
+    pub const _GLIBCXX_USE_LONG_LONG: u32 = 1;
+    pub const _GLIBCXX_USE_NANOSLEEP: u32 = 1;
+    pub const _GLIBCXX_USE_NLS: u32 = 1;
+    pub const _GLIBCXX_USE_PTHREAD_RWLOCK_T: u32 = 1;
+    pub const _GLIBCXX_USE_RANDOM_TR1: u32 = 1;
+    pub const _GLIBCXX_USE_REALPATH: u32 = 1;
+    pub const _GLIBCXX_USE_SCHED_YIELD: u32 = 1;
+    pub const _GLIBCXX_USE_SC_NPROCESSORS_ONLN: u32 = 1;
+    pub const _GLIBCXX_USE_SENDFILE: u32 = 1;
+    pub const _GLIBCXX_USE_ST_MTIM: u32 = 1;
+    pub const _GLIBCXX_USE_TMPNAM: u32 = 1;
+    pub const _GLIBCXX_USE_UTIMENSAT: u32 = 1;
+    pub const _GLIBCXX_USE_WCHAR_T: u32 = 1;
+    pub const _GLIBCXX_VERBOSE: u32 = 1;
+    pub const _GLIBCXX_X86_RDRAND: u32 = 1;
+    pub const _GTHREAD_USE_MUTEX_TIMEDLOCK: u32 = 1;
+    pub const _STDINT_H: u32 = 1;
+    pub const _BITS_WCHAR_H: u32 = 1;
+    pub const __WCHAR_MIN: i32 = -2147483648;
+    pub const __WCHAR_MAX: u32 = 2147483647;
     pub const INT8_MIN: i32 = -128;
     pub const INT16_MIN: i32 = -32768;
     pub const INT32_MIN: i32 = -2147483648;
-    pub const INT64_MIN: i64 = -9223372036854775808;
+    pub const INT8_MAX: u32 = 127;
+    pub const INT16_MAX: u32 = 32767;
+    pub const INT32_MAX: u32 = 2147483647;
     pub const UINT8_MAX: u32 = 255;
     pub const UINT16_MAX: u32 = 65535;
     pub const UINT32_MAX: u32 = 4294967295;
-    pub const UINT64_MAX: i32 = -1;
     pub const INT_LEAST8_MIN: i32 = -128;
     pub const INT_LEAST16_MIN: i32 = -32768;
     pub const INT_LEAST32_MIN: i32 = -2147483648;
-    pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
     pub const INT_LEAST8_MAX: u32 = 127;
     pub const INT_LEAST16_MAX: u32 = 32767;
     pub const INT_LEAST32_MAX: u32 = 2147483647;
-    pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
     pub const UINT_LEAST8_MAX: u32 = 255;
     pub const UINT_LEAST16_MAX: u32 = 65535;
     pub const UINT_LEAST32_MAX: u32 = 4294967295;
-    pub const UINT_LEAST64_MAX: i32 = -1;
     pub const INT_FAST8_MIN: i32 = -128;
-    pub const INT_FAST16_MIN: i32 = -32768;
-    pub const INT_FAST32_MIN: i32 = -2147483648;
-    pub const INT_FAST64_MIN: i64 = -9223372036854775808;
+    pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+    pub const INT_FAST32_MIN: i64 = -9223372036854775808;
     pub const INT_FAST8_MAX: u32 = 127;
-    pub const INT_FAST16_MAX: u32 = 32767;
-    pub const INT_FAST32_MAX: u32 = 2147483647;
-    pub const INT_FAST64_MAX: u64 = 9223372036854775807;
+    pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+    pub const INT_FAST32_MAX: u64 = 9223372036854775807;
     pub const UINT_FAST8_MAX: u32 = 255;
-    pub const UINT_FAST16_MAX: u32 = 65535;
-    pub const UINT_FAST32_MAX: u32 = 4294967295;
-    pub const UINT_FAST64_MAX: i32 = -1;
-    pub const INTPTR_MAX: u64 = 9223372036854775807;
+    pub const UINT_FAST16_MAX: i32 = -1;
+    pub const UINT_FAST32_MAX: i32 = -1;
     pub const INTPTR_MIN: i64 = -9223372036854775808;
+    pub const INTPTR_MAX: u64 = 9223372036854775807;
     pub const UINTPTR_MAX: i32 = -1;
-    pub const SIZE_MAX: i32 = -1;
-    pub const WINT_MIN: i32 = -2147483648;
-    pub const WINT_MAX: u32 = 2147483647;
+    pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+    pub const PTRDIFF_MAX: u64 = 9223372036854775807;
     pub const SIG_ATOMIC_MIN: i32 = -2147483648;
     pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+    pub const SIZE_MAX: i32 = -1;
+    pub const WCHAR_MIN: i32 = -2147483648;
+    pub const WCHAR_MAX: u32 = 2147483647;
+    pub const WINT_MIN: u32 = 0;
+    pub const WINT_MAX: u32 = 4294967295;
     pub mod std {
         #[allow(unused_imports)]
         use self::super::super::root;
+        pub type size_t = ::std::os::raw::c_ulong;
+        pub type nullptr_t = *const ::std::os::raw::c_void;
     }
-    pub type int_least8_t = i8;
-    pub type int_least16_t = i16;
-    pub type int_least32_t = i32;
-    pub type int_least64_t = i64;
-    pub type uint_least8_t = u8;
-    pub type uint_least16_t = u16;
-    pub type uint_least32_t = u32;
-    pub type uint_least64_t = u64;
-    pub type int_fast8_t = i8;
-    pub type int_fast16_t = i16;
-    pub type int_fast32_t = i32;
-    pub type int_fast64_t = i64;
-    pub type uint_fast8_t = u8;
-    pub type uint_fast16_t = u16;
-    pub type uint_fast32_t = u32;
-    pub type uint_fast64_t = u64;
-    pub type __int8_t = ::std::os::raw::c_schar;
-    pub type __uint8_t = ::std::os::raw::c_uchar;
-    pub type __int16_t = ::std::os::raw::c_short;
-    pub type __uint16_t = ::std::os::raw::c_ushort;
-    pub type __int32_t = ::std::os::raw::c_int;
-    pub type __uint32_t = ::std::os::raw::c_uint;
-    pub type __int64_t = ::std::os::raw::c_longlong;
-    pub type __uint64_t = ::std::os::raw::c_ulonglong;
-    pub type __darwin_intptr_t = ::std::os::raw::c_long;
-    pub type __darwin_natural_t = ::std::os::raw::c_uint;
-    pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
-    #[repr(C)]
-    pub struct __mbstate_t {
-        pub __mbstate8: root::__BindgenUnionField<[::std::os::raw::c_char; 128usize]>,
-        pub _mbstateL: root::__BindgenUnionField<::std::os::raw::c_longlong>,
-        pub bindgen_union_field: [u64; 16usize],
+    pub mod __gnu_cxx {
+        #[allow(unused_imports)]
+        use self::super::super::root;
     }
-    pub type __darwin_mbstate_t = root::__mbstate_t;
-    pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-    pub type __darwin_size_t = ::std::os::raw::c_ulong;
-    pub type __darwin_va_list = root::__builtin_va_list;
-    pub type __darwin_wchar_t = ::std::os::raw::c_int;
-    pub type __darwin_rune_t = root::__darwin_wchar_t;
-    pub type __darwin_wint_t = ::std::os::raw::c_int;
-    pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-    pub type __darwin_socklen_t = root::__uint32_t;
-    pub type __darwin_ssize_t = ::std::os::raw::c_long;
-    pub type __darwin_time_t = ::std::os::raw::c_long;
-    pub type __darwin_blkcnt_t = root::__int64_t;
-    pub type __darwin_blksize_t = root::__int32_t;
-    pub type __darwin_dev_t = root::__int32_t;
-    pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-    pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-    pub type __darwin_gid_t = root::__uint32_t;
-    pub type __darwin_id_t = root::__uint32_t;
-    pub type __darwin_ino64_t = root::__uint64_t;
-    pub type __darwin_ino_t = root::__darwin_ino64_t;
-    pub type __darwin_mach_port_name_t = root::__darwin_natural_t;
-    pub type __darwin_mach_port_t = root::__darwin_mach_port_name_t;
-    pub type __darwin_mode_t = root::__uint16_t;
-    pub type __darwin_off_t = root::__int64_t;
-    pub type __darwin_pid_t = root::__int32_t;
-    pub type __darwin_sigset_t = root::__uint32_t;
-    pub type __darwin_suseconds_t = root::__int32_t;
-    pub type __darwin_uid_t = root::__uint32_t;
-    pub type __darwin_useconds_t = root::__uint32_t;
-    pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-    pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
-    #[repr(C)]
-    #[derive(Debug)]
-    pub struct __darwin_pthread_handler_rec {
-        pub __routine:
-            ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-        pub __arg: *mut ::std::os::raw::c_void,
-        pub __next: *mut root::__darwin_pthread_handler_rec,
-    }
-    #[repr(C)]
-    pub struct _opaque_pthread_attr_t {
-        pub __sig: ::std::os::raw::c_long,
-        pub __opaque: [::std::os::raw::c_char; 56usize],
-    }
-    #[repr(C)]
-    pub struct _opaque_pthread_cond_t {
-        pub __sig: ::std::os::raw::c_long,
-        pub __opaque: [::std::os::raw::c_char; 40usize],
-    }
-    #[repr(C)]
-    #[derive(Debug)]
-    pub struct _opaque_pthread_condattr_t {
-        pub __sig: ::std::os::raw::c_long,
-        pub __opaque: [::std::os::raw::c_char; 8usize],
-    }
-    #[repr(C)]
-    pub struct _opaque_pthread_mutex_t {
-        pub __sig: ::std::os::raw::c_long,
-        pub __opaque: [::std::os::raw::c_char; 56usize],
-    }
-    #[repr(C)]
-    #[derive(Debug)]
-    pub struct _opaque_pthread_mutexattr_t {
-        pub __sig: ::std::os::raw::c_long,
-        pub __opaque: [::std::os::raw::c_char; 8usize],
-    }
-    #[repr(C)]
-    #[derive(Debug)]
-    pub struct _opaque_pthread_once_t {
-        pub __sig: ::std::os::raw::c_long,
-        pub __opaque: [::std::os::raw::c_char; 8usize],
-    }
-    #[repr(C)]
-    pub struct _opaque_pthread_rwlock_t {
-        pub __sig: ::std::os::raw::c_long,
-        pub __opaque: [::std::os::raw::c_char; 192usize],
-    }
-    #[repr(C)]
-    #[derive(Debug)]
-    pub struct _opaque_pthread_rwlockattr_t {
-        pub __sig: ::std::os::raw::c_long,
-        pub __opaque: [::std::os::raw::c_char; 16usize],
-    }
-    #[repr(C)]
-    pub struct _opaque_pthread_t {
-        pub __sig: ::std::os::raw::c_long,
-        pub __cleanup_stack: *mut root::__darwin_pthread_handler_rec,
-        pub __opaque: [::std::os::raw::c_char; 8176usize],
-    }
-    pub type __darwin_pthread_attr_t = root::_opaque_pthread_attr_t;
-    pub type __darwin_pthread_cond_t = root::_opaque_pthread_cond_t;
-    pub type __darwin_pthread_condattr_t = root::_opaque_pthread_condattr_t;
-    pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-    pub type __darwin_pthread_mutex_t = root::_opaque_pthread_mutex_t;
-    pub type __darwin_pthread_mutexattr_t = root::_opaque_pthread_mutexattr_t;
-    pub type __darwin_pthread_once_t = root::_opaque_pthread_once_t;
-    pub type __darwin_pthread_rwlock_t = root::_opaque_pthread_rwlock_t;
-    pub type __darwin_pthread_rwlockattr_t = root::_opaque_pthread_rwlockattr_t;
-    pub type __darwin_pthread_t = *mut root::_opaque_pthread_t;
-    pub type u_int8_t = ::std::os::raw::c_uchar;
-    pub type u_int16_t = ::std::os::raw::c_ushort;
-    pub type u_int32_t = ::std::os::raw::c_uint;
-    pub type u_int64_t = ::std::os::raw::c_ulonglong;
-    pub type register_t = i64;
-    pub type user_addr_t = root::u_int64_t;
-    pub type user_size_t = root::u_int64_t;
-    pub type user_ssize_t = i64;
-    pub type user_long_t = i64;
-    pub type user_ulong_t = root::u_int64_t;
-    pub type user_time_t = i64;
-    pub type user_off_t = i64;
-    pub type syscall_arg_t = root::u_int64_t;
+    pub type int_least8_t = ::std::os::raw::c_schar;
+    pub type int_least16_t = ::std::os::raw::c_short;
+    pub type int_least32_t = ::std::os::raw::c_int;
+    pub type int_least64_t = ::std::os::raw::c_long;
+    pub type uint_least8_t = ::std::os::raw::c_uchar;
+    pub type uint_least16_t = ::std::os::raw::c_ushort;
+    pub type uint_least32_t = ::std::os::raw::c_uint;
+    pub type uint_least64_t = ::std::os::raw::c_ulong;
+    pub type int_fast8_t = ::std::os::raw::c_schar;
+    pub type int_fast16_t = ::std::os::raw::c_long;
+    pub type int_fast32_t = ::std::os::raw::c_long;
+    pub type int_fast64_t = ::std::os::raw::c_long;
+    pub type uint_fast8_t = ::std::os::raw::c_uchar;
+    pub type uint_fast16_t = ::std::os::raw::c_ulong;
+    pub type uint_fast32_t = ::std::os::raw::c_ulong;
+    pub type uint_fast64_t = ::std::os::raw::c_ulong;
     pub type intmax_t = ::std::os::raw::c_long;
     pub type uintmax_t = ::std::os::raw::c_ulong;
     pub mod DB {
@@ -536,6 +613,13 @@ pub mod root {
                 ) -> root::DB::RawVoidPtr,
             >,
             pub sst_reader_interfaces: root::DB::SSTReaderInterfaces,
+            pub fn_server_info: ::std::option::Option<
+                unsafe extern "C" fn(
+                    arg1: root::DB::RaftStoreProxyPtr,
+                    arg2: root::DB::BaseBuffView,
+                    arg3: root::DB::RawVoidPtr,
+                ) -> u32,
+            >,
         }
         #[repr(C)]
         #[derive(Debug)]
@@ -631,17 +715,11 @@ pub mod root {
                     arg3: u64,
                 ),
             >,
+            pub fn_set_server_info_resp: ::std::option::Option<
+                unsafe extern "C" fn(arg1: root::DB::BaseBuffView, arg2: root::DB::RawVoidPtr),
+            >,
         }
-        pub const RAFT_STORE_PROXY_VERSION: u32 = 501000;
+        pub const RAFT_STORE_PROXY_VERSION: u32 = 501001;
         pub const RAFT_STORE_PROXY_MAGIC_NUMBER: u32 = 324508639;
-    }
-    pub type __builtin_va_list = [root::__va_list_tag; 1usize];
-    #[repr(C)]
-    #[derive(Debug)]
-    pub struct __va_list_tag {
-        pub gp_offset: ::std::os::raw::c_uint,
-        pub fp_offset: ::std::os::raw::c_uint,
-        pub overflow_arg_area: *mut ::std::os::raw::c_void,
-        pub reg_save_area: *mut ::std::os::raw::c_void,
     }
 }

--- a/components/raftstore/src/engine_store_ffi/mod.rs
+++ b/components/raftstore/src/engine_store_ffi/mod.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-mod interfaces;
+pub mod interfaces;
 
 mod read_index_helper;
 
@@ -68,7 +68,7 @@ impl RaftStoreProxyPtr {
     unsafe fn as_ref(&self) -> &RaftStoreProxy {
         &*(self.inner as *const RaftStoreProxy)
     }
-    fn is_null(&self) -> bool {
+    pub fn is_null(&self) -> bool {
         self.inner == std::ptr::null()
     }
 }
@@ -384,6 +384,7 @@ impl RaftStoreProxyFFIHelper {
                 fn_next: Some(ffi_next),
                 fn_gc: Some(ffi_gc),
             },
+            fn_server_info: None,
         }
     }
 }
@@ -497,12 +498,12 @@ impl RaftCmdHeader {
     }
 }
 
-struct ProtoMsgBaseBuff {
+pub struct ProtoMsgBaseBuff {
     data: Vec<u8>,
 }
 
 impl ProtoMsgBaseBuff {
-    fn new<T: protobuf::Message>(msg: &T) -> Self {
+    pub fn new<T: protobuf::Message>(msg: &T) -> Self {
         ProtoMsgBaseBuff {
             data: msg.write_to_bytes().unwrap(),
         }
@@ -708,5 +709,9 @@ impl EngineStoreServerHelper {
 
     pub fn check_http_uri_available(&self, path: &str) -> bool {
         unsafe { (self.fn_check_http_uri_available.into_inner())(path.as_bytes().into()) != 0 }
+    }
+
+    pub fn set_server_info_resp(&self, res: BaseBuffView, ptr: RawVoidPtr) {
+        unsafe { (self.fn_set_server_info_resp.into_inner())(res, ptr) }
     }
 }

--- a/components/server/src/lib.rs
+++ b/components/server/src/lib.rs
@@ -11,6 +11,7 @@ pub mod memory;
 mod proxy;
 pub mod raft_engine_switch;
 mod server;
+mod util;
 
 fn proxy_version_info() -> String {
     let fallback = "Unknown (env var does not exist when building)";

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -98,6 +98,7 @@ use tikv_util::{
 use tokio::runtime::Builder;
 
 use crate::raft_engine_switch::{check_and_dump_raft_db, check_and_dump_raft_engine};
+use crate::util::ffi_server_info;
 use crate::{memory::*, setup::*};
 use raftstore::engine_store_ffi::{
     get_engine_store_server_helper, EngineStoreServerStatus, RaftProxyStatus, RaftStoreProxy,
@@ -147,7 +148,11 @@ pub unsafe fn run_tikv(config: TiKvConfig) {
                 )),
             };
 
-            let proxy_helper = RaftStoreProxyFFIHelper::new(&proxy);
+            let proxy_helper = {
+                let mut proxy_helper = RaftStoreProxyFFIHelper::new(&proxy);
+                proxy_helper.fn_server_info = Some(ffi_server_info);
+                proxy_helper
+            };
 
             info!("set raft-store proxy helper");
 

--- a/components/server/src/util.rs
+++ b/components/server/src/util.rs
@@ -1,0 +1,81 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use kvproto::diagnosticspb::{ServerInfoRequest, ServerInfoResponse, ServerInfoType};
+use protobuf::Message;
+use raftstore::engine_store_ffi::interfaces::root::DB::{
+    BaseBuffView, RaftStoreProxyPtr, RawVoidPtr,
+};
+use raftstore::engine_store_ffi::{get_engine_store_server_helper, ProtoMsgBaseBuff};
+
+use futures::compat::Future01CompatExt;
+use futures::executor::block_on;
+use std::borrow::Borrow;
+use std::time::{Duration, Instant};
+use tikv::server::service::diagnostics::sys;
+use tikv::server::service::diagnostics::{ioload, SYS_INFO};
+use tikv_util::{sys::SystemExt, timer::GLOBAL_TIMER_HANDLE};
+
+fn server_info_for_ffi(req: ServerInfoRequest) -> ServerInfoResponse {
+    let tp = req.get_tp();
+
+    let collect = async move {
+        let (load, when) = match tp {
+            ServerInfoType::LoadInfo | ServerInfoType::All => {
+                let mut system = SYS_INFO.lock().unwrap();
+                system.refresh_networks_list();
+                system.refresh_all();
+                let load = (
+                    sys::cpu_time_snapshot(),
+                    system
+                        .get_networks()
+                        .into_iter()
+                        .map(|(n, d)| (n.to_owned(), sys::NicSnapshot::from_network_data(d)))
+                        .collect(),
+                    ioload::IoLoad::snapshot(),
+                );
+                let when = Instant::now() + Duration::from_millis(1000);
+                (Some(load), when)
+            }
+            _ => (None, Instant::now()),
+        };
+
+        let timer = GLOBAL_TIMER_HANDLE.clone();
+        let _ = timer.delay(when).compat().await;
+
+        let mut server_infos = Vec::new();
+        match req.get_tp() {
+            ServerInfoType::HardwareInfo => sys::hardware_info(&mut server_infos),
+            ServerInfoType::LoadInfo => sys::load_info(load.unwrap(), &mut server_infos),
+            ServerInfoType::SystemInfo => sys::system_info(&mut server_infos),
+            ServerInfoType::All => {
+                sys::hardware_info(&mut server_infos);
+                sys::load_info(load.unwrap(), &mut server_infos);
+                sys::system_info(&mut server_infos);
+            }
+        };
+        server_infos.sort_by(|a, b| (a.get_tp(), a.get_name()).cmp(&(b.get_tp(), b.get_name())));
+        let mut resp = ServerInfoResponse::default();
+        resp.set_items(server_infos.into());
+        resp
+    };
+
+    block_on(collect)
+}
+
+#[no_mangle]
+pub extern "C" fn ffi_server_info(
+    proxy_ptr: RaftStoreProxyPtr,
+    view: BaseBuffView,
+    res: RawVoidPtr,
+) -> u32 {
+    assert!(!proxy_ptr.is_null());
+    let mut req = ServerInfoRequest::default();
+    assert_ne!(view.data, std::ptr::null());
+    assert_ne!(view.len, 0);
+    req.merge_from_bytes(view.to_slice()).unwrap();
+
+    let resp = server_info_for_ffi(req);
+    let r = ProtoMsgBaseBuff::new(&resp);
+    get_engine_store_server_helper().set_server_info_resp(r.borrow().into(), res);
+    0
+}

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
@@ -1,4 +1,4 @@
-//ef3c0a05cdfd04ac7f95eac4a3be74d2//501000//
+//0e0095b0e500d4b94f4ee8962689b8de//501001//
 #pragma once
 #include <cstdint>
-namespace DB { constexpr uint32_t RAFT_STORE_PROXY_VERSION = 501000; }
+namespace DB { constexpr uint32_t RAFT_STORE_PROXY_VERSION = 501001; }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
@@ -136,6 +136,8 @@ struct RaftStoreProxyFFIHelper {
   RawVoidPtr (*fn_handle_batch_read_index)(RaftStoreProxyPtr, CppStrVecView,
                                            uint64_t);
   SSTReaderInterfaces sst_reader_interfaces;
+
+  uint32_t (*fn_server_info)(RaftStoreProxyPtr, BaseBuffView, RawVoidPtr);
 };
 
 struct EngineStoreServerHelper {
@@ -170,5 +172,6 @@ struct EngineStoreServerHelper {
   void (*fn_gc_raw_cpp_ptr)(EngineStoreServerWrap *, RawVoidPtr, RawCppPtrType);
   RawVoidPtr (*fn_gen_batch_read_index_res)(uint64_t);
   void (*fn_insert_batch_read_index_resp)(RawVoidPtr, BaseBuffView, uint64_t);
+  void (*fn_set_server_info_resp)(BaseBuffView, RawVoidPtr);
 };
 }  // namespace DB

--- a/src/server/service/diagnostics/mod.rs
+++ b/src/server/service/diagnostics/mod.rs
@@ -23,9 +23,9 @@ use kvproto::diagnosticspb::{
 use tikv_util::{sys::SystemExt, timer::GLOBAL_TIMER_HANDLE};
 use tokio::runtime::Handle;
 
-mod ioload;
+pub mod ioload;
 mod log;
-mod sys;
+pub mod sys;
 
 lazy_static! {
     pub static ref SYS_INFO: Mutex<sysinfo::System> = Mutex::new(sysinfo::System::new());

--- a/src/server/service/mod.rs
+++ b/src/server/service/mod.rs
@@ -2,7 +2,7 @@
 
 mod batch;
 mod debug;
-mod diagnostics;
+pub mod diagnostics;
 mod kv;
 
 pub use self::debug::Service as DebugService;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Support `fn_server_info` to forward server info from proxy to TiFlash.

### What is changed and how it works?

What's Changed:

add `fn_server_info` to `RaftStoreProxyFFIHelper`.
add `ffi_server_info` as implementation of `fn_server_info`.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```