### PR TITLE
fix unsafe wrap by using std::pin::Pin

### DIFF
--- a/components/raftstore/src/engine_store_ffi/mod.rs
+++ b/components/raftstore/src/engine_store_ffi/mod.rs
@@ -465,6 +465,9 @@ impl WriteCmds {
     pub fn len(&self) -> usize {
         self.cmd_type.len()
     }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     fn gen_view(&self) -> WriteCmdsView {
         WriteCmdsView {
@@ -541,6 +544,8 @@ pub fn get_engine_store_server_helper() -> &'static EngineStoreServerHelper {
     unsafe { &(*(ENGINE_STORE_SERVER_HELPER_PTR as *const EngineStoreServerHelper)) }
 }
 
+/// # Safety
+/// The lifetime of `engine_store_server_helper` is definitely longer than `ENGINE_STORE_SERVER_HELPER_PTR`.
 pub unsafe fn init_engine_store_server_helper(engine_store_server_helper: *const u8) {
     let ptr = &ENGINE_STORE_SERVER_HELPER_PTR as *const _ as *mut _;
     *ptr = engine_store_server_helper;

--- a/components/raftstore/src/engine_store_ffi/read_index_helper.rs
+++ b/components/raftstore/src/engine_store_ffi/read_index_helper.rs
@@ -114,20 +114,16 @@ impl<ER: RaftEngine> ReadIndex for ReadIndexClient<ER> {
         let finished = {
             let read_index_res = &mut read_index_res;
             let read_index_fut = async {
-                loop {
-                    if let Some((fut, region_id)) = router_cbs.front_mut() {
-                        let res = match fut {
-                            None => None,
-                            Some(fut) => match fut.await {
-                                Err(_) => None,
-                                Ok(e) => Some(e),
-                            },
-                        };
-                        read_index_res.push((into_read_index_response(res), *region_id));
-                        router_cbs.pop_front();
-                    } else {
-                        break;
-                    }
+                while let Some((fut, region_id)) = router_cbs.front_mut() {
+                    let res = match fut {
+                        None => None,
+                        Some(fut) => match fut.await {
+                            Err(_) => None,
+                            Ok(e) => Some(e),
+                        },
+                    };
+                    read_index_res.push((into_read_index_response(res), *region_id));
+                    router_cbs.pop_front();
                 }
             };
 
@@ -144,28 +140,24 @@ impl<ER: RaftEngine> ReadIndex for ReadIndexClient<ER> {
         };
         if !finished {
             let read_index_res = &mut read_index_res;
-            loop {
-                if let Some((cb, region_id)) = router_cbs.front_mut() {
-                    let res = match cb {
-                        None => None,
-                        Some(fut) => {
-                            let waker = futures::task::noop_waker();
-                            let cx = &mut std::task::Context::from_waker(&waker);
-                            futures::pin_mut!(fut);
-                            match fut.poll(cx) {
-                                std::task::Poll::Pending => None,
-                                std::task::Poll::Ready(e) => match e {
-                                    Err(_) => None,
-                                    Ok(e) => Some(e),
-                                },
-                            }
+            while let Some((cb, region_id)) = router_cbs.front_mut() {
+                let res = match cb {
+                    None => None,
+                    Some(fut) => {
+                        let waker = futures::task::noop_waker();
+                        let cx = &mut std::task::Context::from_waker(&waker);
+                        futures::pin_mut!(fut);
+                        match fut.poll(cx) {
+                            std::task::Poll::Pending => None,
+                            std::task::Poll::Ready(e) => match e {
+                                Err(_) => None,
+                                Ok(e) => Some(e),
+                            },
                         }
-                    };
-                    read_index_res.push((into_read_index_response(res), *region_id));
-                    router_cbs.pop_front();
-                } else {
-                    break;
-                }
+                    }
+                };
+                read_index_res.push((into_read_index_response(res), *region_id));
+                router_cbs.pop_front();
             }
         }
         assert_eq!(req_vec.len(), read_index_res.len());

--- a/components/raftstore/src/engine_store_ffi/read_index_helper.rs
+++ b/components/raftstore/src/engine_store_ffi/read_index_helper.rs
@@ -39,10 +39,7 @@ fn into_read_index_response<S: engine_traits::Snapshot>(
     res: Option<ReadResponse<S>>,
 ) -> kvproto::kvrpcpb::ReadIndexResponse {
     let mut resp = ReadIndexResponse::default();
-    if res.is_none() {
-        resp.set_region_error(Default::default());
-    } else {
-        let mut res = res.unwrap();
+    if let Some(mut res) = res {
         if res.response.get_header().has_error() {
             resp.set_region_error(res.response.mut_header().take_error());
         } else {
@@ -65,6 +62,8 @@ fn into_read_index_response<S: engine_traits::Snapshot>(
                 }
             }
         }
+    } else {
+        resp.set_region_error(Default::default());
     }
     resp
 }

--- a/components/server/src/util.rs
+++ b/components/server/src/util.rs
@@ -9,7 +9,7 @@ use raftstore::engine_store_ffi::{get_engine_store_server_helper, ProtoMsgBaseBu
 
 use futures::compat::Future01CompatExt;
 use futures::executor::block_on;
-use std::borrow::Borrow;
+use std::pin::Pin;
 use std::time::{Duration, Instant};
 use tikv::server::service::diagnostics::sys;
 use tikv::server::service::diagnostics::{ioload, SYS_INFO};
@@ -76,6 +76,6 @@ pub extern "C" fn ffi_server_info(
 
     let resp = server_info_for_ffi(req);
     let r = ProtoMsgBaseBuff::new(&resp);
-    get_engine_store_server_helper().set_server_info_resp(r.borrow().into(), res);
+    get_engine_store_server_helper().set_server_info_resp(Pin::new(&r).into(), res);
     0
 }

--- a/components/tikv_util/src/metrics/threads_linux.rs
+++ b/components/tikv_util/src/metrics/threads_linux.rs
@@ -484,7 +484,7 @@ pub fn dump_thread_stats() -> String {
             res.push(stat);
         }
     }
-    format!("total count {}\n{:#?}", res.len(), res).into()
+    format!("total count {}\n{:#?}", res.len(), res)
 }
 
 #[cfg(test)]

--- a/gen-proxy-ffi.sh
+++ b/gen-proxy-ffi.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+ARGS=""
+
+if [[ -n ${OVERWRITE_VERSION} ]]; then
+    ARGS="${ARGS} --overwrite-version=${OVERWRITE_VERSION}"
+fi
+
 set -ex
 
 ffi_path="raftstore-proxy/ffi"
 ./${ffi_path}/format.sh
-cargo run --package gen-proxy-ffi --bin gen-proxy-ffi
+cargo run --package gen-proxy-ffi --bin gen-proxy-ffi -- ${ARGS}

--- a/raftstore-proxy/src/lib.rs
+++ b/raftstore-proxy/src/lib.rs
@@ -1,10 +1,14 @@
 use std::os::raw::{c_char, c_int};
 
+/// # Safety
+/// Print version infomatin to std output.
 #[no_mangle]
 pub unsafe extern "C" fn print_raftstore_proxy_version() {
     server::print_proxy_version();
 }
 
+/// # Safety
+/// Please make sure such function will be run in an independent thread. Usage about interfaces can be found in `struct EngineStoreServerHelper`.
 #[no_mangle]
 pub unsafe extern "C" fn run_raftstore_proxy_ffi(
     argc: c_int,

--- a/readme.md
+++ b/readme.md
@@ -117,36 +117,6 @@ scenes equivalent to TiKV. The main battlefields of it are about `HTAP` or OLAP.
 consider about distributed fault tolerance/recovery or automatic re-balancing, because the library itself has inherited
 these important features from TiKV.
 
-<!--
-A discussion of alternate approaches and the trade-offs, advantages, and disadvantages of the specified approach:
-- How other systems solve the same issue?
-- What other designs have been considered and what are their disadvantages?
-- What is the advantage of this design compared with other designs?
-- What is the disadvantage of this design?
-- What is the impact of not doing this?
--->
-
-
-<!--
-## Compatibility and Migration Plan
-
-A discussion of the change with regard to the compatibility issues:
-- Does this proposal make TiDB not compatible with the old versions?
-- Does this proposal make TiDB not compatible with TiDB tools?
-    + [BR](https://github.com/pingcap/br)
-    + [DM](https://github.com/pingcap/dm)
-    + [Dumpling](https://github.com/pingcap/dumpling)
-    + [TiCDC](https://github.com/pingcap/ticdc)
-    + [TiDB Binlog](https://github.com/pingcap/tidb-binlog)
-    + [TiDB Lightning](https://github.com/pingcap/tidb-lightning)
-- If the existing behavior will be changed, how will we phase out the older behavior?
-- Does this proposal make TiDB more compatible with MySQL?
-- What is the impact(if any) on the data migration:
-    + from MySQL to TiDB
-    + from TiDB to MySQL
-    + from old TiDB cluster to new TiDB cluster
--->
-
 ## Implementation
 
 There are total two exposed functions:


### PR DESCRIPTION
Signed-off-by: Zhigao Tong <tongzhigao@pingcap.com>

### What problem does this PR solve?

Problem Summary:

`impl From<&ProtoMsgBaseBuff> for BaseBuffView` is not safe because it's available to use like `ProtoMsgBaseBuff::new(msg).borrow().into()`, The lifetime temporary `ProtoMsgBaseBuff` may be shorter than BaseBuffView.

### What is changed and how it works?

What's Changed:

use `std::pin::Pin` to wrap and make sure object of `ProtoMsgBaseBuff` pin its value in place

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```