### PR TITLE
Refine ffi interfaces and remove global variables coupling

### DIFF
--- a/components/raftstore/src/engine_store_ffi/interfaces.rs
+++ b/components/raftstore/src/engine_store_ffi/interfaces.rs
@@ -6,8 +6,8 @@ pub mod root {
     use self::super::root;
     pub const _GLIBCXX_CSTDINT: u32 = 1;
     pub const _GLIBCXX_CXX_CONFIG_H: u32 = 1;
-    pub const _GLIBCXX_RELEASE: u32 = 7;
-    pub const __GLIBCXX__: u32 = 20180125;
+    pub const _GLIBCXX_RELEASE: u32 = 8;
+    pub const __GLIBCXX__: u32 = 20190406;
     pub const _GLIBCXX_HAVE_ATTRIBUTE_VISIBILITY: u32 = 1;
     pub const _GLIBCXX_USE_DEPRECATED: u32 = 1;
     pub const _GLIBCXX_EXTERN_TEMPLATE: u32 = 1;
@@ -18,7 +18,6 @@ pub mod root {
     pub const _GLIBCXX_OS_DEFINES: u32 = 1;
     pub const __NO_CTYPE: u32 = 1;
     pub const _FEATURES_H: u32 = 1;
-    pub const __USE_ANSI: u32 = 1;
     pub const _ISOC95_SOURCE: u32 = 1;
     pub const _ISOC99_SOURCE: u32 = 1;
     pub const _ISOC11_SOURCE: u32 = 1;
@@ -27,8 +26,7 @@ pub mod root {
     pub const _XOPEN_SOURCE: u32 = 700;
     pub const _XOPEN_SOURCE_EXTENDED: u32 = 1;
     pub const _LARGEFILE64_SOURCE: u32 = 1;
-    pub const _BSD_SOURCE: u32 = 1;
-    pub const _SVID_SOURCE: u32 = 1;
+    pub const _DEFAULT_SOURCE: u32 = 1;
     pub const _ATFILE_SOURCE: u32 = 1;
     pub const __USE_ISOC11: u32 = 1;
     pub const __USE_ISOC99: u32 = 1;
@@ -49,26 +47,26 @@ pub mod root {
     pub const __USE_LARGEFILE: u32 = 1;
     pub const __USE_LARGEFILE64: u32 = 1;
     pub const __USE_MISC: u32 = 1;
-    pub const __USE_BSD: u32 = 1;
-    pub const __USE_SVID: u32 = 1;
     pub const __USE_ATFILE: u32 = 1;
     pub const __USE_GNU: u32 = 1;
     pub const __USE_FORTIFY_LEVEL: u32 = 0;
+    pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 1;
     pub const _STDC_PREDEF_H: u32 = 1;
     pub const __STDC_IEC_559__: u32 = 1;
     pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
-    pub const __STDC_ISO_10646__: u32 = 201103;
-    pub const __STDC_NO_THREADS__: u32 = 1;
+    pub const __STDC_ISO_10646__: u32 = 201706;
     pub const __GNU_LIBRARY__: u32 = 6;
     pub const __GLIBC__: u32 = 2;
-    pub const __GLIBC_MINOR__: u32 = 17;
-    pub const __GLIBC_HAVE_LONG_LONG: u32 = 1;
+    pub const __GLIBC_MINOR__: u32 = 28;
     pub const _SYS_CDEFS_H: u32 = 1;
+    pub const __glibc_c99_flexarr_available: u32 = 1;
     pub const __WORDSIZE: u32 = 64;
     pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
     pub const __SYSCALL_WORDSIZE: u32 = 64;
+    pub const __HAVE_GENERIC_SELECTION: u32 = 0;
     pub const _GLIBCXX_CPU_DEFINES: u32 = 1;
     pub const _GLIBCXX_FAST_MATH: u32 = 0;
+    pub const _GLIBCXX_USE_FLOAT128: u32 = 1;
     pub const _GLIBCXX_HAVE_ACOSF: u32 = 1;
     pub const _GLIBCXX_HAVE_ACOSL: u32 = 1;
     pub const _GLIBCXX_HAVE_ALIGNED_ALLOC: u32 = 1;
@@ -136,10 +134,8 @@ pub mod root {
     pub const _GLIBCXX_HAVE_INT64_T: u32 = 1;
     pub const _GLIBCXX_HAVE_INT64_T_LONG: u32 = 1;
     pub const _GLIBCXX_HAVE_INTTYPES_H: u32 = 1;
-    pub const _GLIBCXX_HAVE_ISINF: u32 = 1;
     pub const _GLIBCXX_HAVE_ISINFF: u32 = 1;
     pub const _GLIBCXX_HAVE_ISINFL: u32 = 1;
-    pub const _GLIBCXX_HAVE_ISNAN: u32 = 1;
     pub const _GLIBCXX_HAVE_ISNANF: u32 = 1;
     pub const _GLIBCXX_HAVE_ISNANL: u32 = 1;
     pub const _GLIBCXX_HAVE_ISWBLANK: u32 = 1;
@@ -153,6 +149,8 @@ pub mod root {
     pub const _GLIBCXX_HAVE_LIMIT_RSS: u32 = 1;
     pub const _GLIBCXX_HAVE_LIMIT_VMEM: u32 = 0;
     pub const _GLIBCXX_HAVE_LINUX_FUTEX: u32 = 1;
+    pub const _GLIBCXX_HAVE_LINUX_RANDOM_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_LINUX_TYPES_H: u32 = 1;
     pub const _GLIBCXX_HAVE_LOCALE_H: u32 = 1;
     pub const _GLIBCXX_HAVE_LOG10F: u32 = 1;
     pub const _GLIBCXX_HAVE_LOG10L: u32 = 1;
@@ -164,8 +162,6 @@ pub mod root {
     pub const _GLIBCXX_HAVE_MODF: u32 = 1;
     pub const _GLIBCXX_HAVE_MODFF: u32 = 1;
     pub const _GLIBCXX_HAVE_MODFL: u32 = 1;
-    pub const _GLIBCXX_HAVE_OBSOLETE_ISINF: u32 = 1;
-    pub const _GLIBCXX_HAVE_OBSOLETE_ISNAN: u32 = 1;
     pub const _GLIBCXX_HAVE_POLL: u32 = 1;
     pub const _GLIBCXX_HAVE_POSIX_MEMALIGN: u32 = 1;
     pub const _GLIBCXX_HAVE_POWF: u32 = 1;
@@ -198,6 +194,7 @@ pub mod root {
     pub const _GLIBCXX_HAVE_SYS_IPC_H: u32 = 1;
     pub const _GLIBCXX_HAVE_SYS_PARAM_H: u32 = 1;
     pub const _GLIBCXX_HAVE_SYS_RESOURCE_H: u32 = 1;
+    pub const _GLIBCXX_HAVE_SYS_SDT_H: u32 = 1;
     pub const _GLIBCXX_HAVE_SYS_SEM_H: u32 = 1;
     pub const _GLIBCXX_HAVE_SYS_STATVFS_H: u32 = 1;
     pub const _GLIBCXX_HAVE_SYS_STAT_H: u32 = 1;
@@ -222,6 +219,7 @@ pub mod root {
     pub const _GLIBCXX_HAVE_WCSTOF: u32 = 1;
     pub const _GLIBCXX_HAVE_WCTYPE_H: u32 = 1;
     pub const _GLIBCXX_HAVE_WRITEV: u32 = 1;
+    pub const _GLIBCXX_HAVE___CXA_THREAD_ATEXIT_IMPL: u32 = 1;
     pub const LT_OBJDIR: &'static [u8; 7usize] = b".libs/\0";
     pub const _GLIBCXX_PACKAGE_BUGREPORT: &'static [u8; 1usize] = b"\0";
     pub const _GLIBCXX_PACKAGE_NAME: &'static [u8; 15usize] = b"package-unused\0";
@@ -264,7 +262,6 @@ pub mod root {
     pub const _GLIBCXX_USE_DECIMAL_FLOAT: u32 = 1;
     pub const _GLIBCXX_USE_FCHMOD: u32 = 1;
     pub const _GLIBCXX_USE_FCHMODAT: u32 = 1;
-    pub const _GLIBCXX_USE_FLOAT128: u32 = 1;
     pub const _GLIBCXX_USE_GETTIMEOFDAY: u32 = 1;
     pub const _GLIBCXX_USE_GET_NPROCS: u32 = 1;
     pub const _GLIBCXX_USE_INT128: u32 = 1;
@@ -286,9 +283,19 @@ pub mod root {
     pub const _GLIBCXX_X86_RDRAND: u32 = 1;
     pub const _GTHREAD_USE_MUTEX_TIMEDLOCK: u32 = 1;
     pub const _STDINT_H: u32 = 1;
+    pub const __GLIBC_USE_LIB_EXT2: u32 = 1;
+    pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 1;
+    pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 1;
+    pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 1;
+    pub const _BITS_TYPES_H: u32 = 1;
+    pub const _BITS_TYPESIZES_H: u32 = 1;
+    pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+    pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+    pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+    pub const __FD_SETSIZE: u32 = 1024;
     pub const _BITS_WCHAR_H: u32 = 1;
-    pub const __WCHAR_MIN: i32 = -2147483648;
-    pub const __WCHAR_MAX: u32 = 2147483647;
+    pub const _BITS_STDINT_INTN_H: u32 = 1;
+    pub const _BITS_STDINT_UINTN_H: u32 = 1;
     pub const INT8_MIN: i32 = -128;
     pub const INT16_MIN: i32 = -32768;
     pub const INT32_MIN: i32 = -2147483648;
@@ -324,10 +331,41 @@ pub mod root {
     pub const SIG_ATOMIC_MIN: i32 = -2147483648;
     pub const SIG_ATOMIC_MAX: u32 = 2147483647;
     pub const SIZE_MAX: i32 = -1;
-    pub const WCHAR_MIN: i32 = -2147483648;
-    pub const WCHAR_MAX: u32 = 2147483647;
     pub const WINT_MIN: u32 = 0;
     pub const WINT_MAX: u32 = 4294967295;
+    pub const INT8_WIDTH: u32 = 8;
+    pub const UINT8_WIDTH: u32 = 8;
+    pub const INT16_WIDTH: u32 = 16;
+    pub const UINT16_WIDTH: u32 = 16;
+    pub const INT32_WIDTH: u32 = 32;
+    pub const UINT32_WIDTH: u32 = 32;
+    pub const INT64_WIDTH: u32 = 64;
+    pub const UINT64_WIDTH: u32 = 64;
+    pub const INT_LEAST8_WIDTH: u32 = 8;
+    pub const UINT_LEAST8_WIDTH: u32 = 8;
+    pub const INT_LEAST16_WIDTH: u32 = 16;
+    pub const UINT_LEAST16_WIDTH: u32 = 16;
+    pub const INT_LEAST32_WIDTH: u32 = 32;
+    pub const UINT_LEAST32_WIDTH: u32 = 32;
+    pub const INT_LEAST64_WIDTH: u32 = 64;
+    pub const UINT_LEAST64_WIDTH: u32 = 64;
+    pub const INT_FAST8_WIDTH: u32 = 8;
+    pub const UINT_FAST8_WIDTH: u32 = 8;
+    pub const INT_FAST16_WIDTH: u32 = 64;
+    pub const UINT_FAST16_WIDTH: u32 = 64;
+    pub const INT_FAST32_WIDTH: u32 = 64;
+    pub const UINT_FAST32_WIDTH: u32 = 64;
+    pub const INT_FAST64_WIDTH: u32 = 64;
+    pub const UINT_FAST64_WIDTH: u32 = 64;
+    pub const INTPTR_WIDTH: u32 = 64;
+    pub const UINTPTR_WIDTH: u32 = 64;
+    pub const INTMAX_WIDTH: u32 = 64;
+    pub const UINTMAX_WIDTH: u32 = 64;
+    pub const PTRDIFF_WIDTH: u32 = 64;
+    pub const SIG_ATOMIC_WIDTH: u32 = 32;
+    pub const SIZE_WIDTH: u32 = 64;
+    pub const WCHAR_WIDTH: u32 = 32;
+    pub const WINT_WIDTH: u32 = 32;
     pub mod std {
         #[allow(unused_imports)]
         use self::super::super::root;
@@ -338,14 +376,80 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
     }
-    pub type int_least8_t = ::std::os::raw::c_schar;
-    pub type int_least16_t = ::std::os::raw::c_short;
-    pub type int_least32_t = ::std::os::raw::c_int;
-    pub type int_least64_t = ::std::os::raw::c_long;
-    pub type uint_least8_t = ::std::os::raw::c_uchar;
-    pub type uint_least16_t = ::std::os::raw::c_ushort;
-    pub type uint_least32_t = ::std::os::raw::c_uint;
-    pub type uint_least64_t = ::std::os::raw::c_ulong;
+    pub type __u_char = ::std::os::raw::c_uchar;
+    pub type __u_short = ::std::os::raw::c_ushort;
+    pub type __u_int = ::std::os::raw::c_uint;
+    pub type __u_long = ::std::os::raw::c_ulong;
+    pub type __int8_t = ::std::os::raw::c_schar;
+    pub type __uint8_t = ::std::os::raw::c_uchar;
+    pub type __int16_t = ::std::os::raw::c_short;
+    pub type __uint16_t = ::std::os::raw::c_ushort;
+    pub type __int32_t = ::std::os::raw::c_int;
+    pub type __uint32_t = ::std::os::raw::c_uint;
+    pub type __int64_t = ::std::os::raw::c_long;
+    pub type __uint64_t = ::std::os::raw::c_ulong;
+    pub type __int_least8_t = root::__int8_t;
+    pub type __uint_least8_t = root::__uint8_t;
+    pub type __int_least16_t = root::__int16_t;
+    pub type __uint_least16_t = root::__uint16_t;
+    pub type __int_least32_t = root::__int32_t;
+    pub type __uint_least32_t = root::__uint32_t;
+    pub type __int_least64_t = root::__int64_t;
+    pub type __uint_least64_t = root::__uint64_t;
+    pub type __quad_t = ::std::os::raw::c_long;
+    pub type __u_quad_t = ::std::os::raw::c_ulong;
+    pub type __intmax_t = ::std::os::raw::c_long;
+    pub type __uintmax_t = ::std::os::raw::c_ulong;
+    pub type __dev_t = ::std::os::raw::c_ulong;
+    pub type __uid_t = ::std::os::raw::c_uint;
+    pub type __gid_t = ::std::os::raw::c_uint;
+    pub type __ino_t = ::std::os::raw::c_ulong;
+    pub type __ino64_t = ::std::os::raw::c_ulong;
+    pub type __mode_t = ::std::os::raw::c_uint;
+    pub type __nlink_t = ::std::os::raw::c_ulong;
+    pub type __off_t = ::std::os::raw::c_long;
+    pub type __off64_t = ::std::os::raw::c_long;
+    pub type __pid_t = ::std::os::raw::c_int;
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct __fsid_t {
+        pub __val: [::std::os::raw::c_int; 2usize],
+    }
+    pub type __clock_t = ::std::os::raw::c_long;
+    pub type __rlim_t = ::std::os::raw::c_ulong;
+    pub type __rlim64_t = ::std::os::raw::c_ulong;
+    pub type __id_t = ::std::os::raw::c_uint;
+    pub type __time_t = ::std::os::raw::c_long;
+    pub type __useconds_t = ::std::os::raw::c_uint;
+    pub type __suseconds_t = ::std::os::raw::c_long;
+    pub type __daddr_t = ::std::os::raw::c_int;
+    pub type __key_t = ::std::os::raw::c_int;
+    pub type __clockid_t = ::std::os::raw::c_int;
+    pub type __timer_t = *mut ::std::os::raw::c_void;
+    pub type __blksize_t = ::std::os::raw::c_long;
+    pub type __blkcnt_t = ::std::os::raw::c_long;
+    pub type __blkcnt64_t = ::std::os::raw::c_long;
+    pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+    pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+    pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+    pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+    pub type __fsword_t = ::std::os::raw::c_long;
+    pub type __ssize_t = ::std::os::raw::c_long;
+    pub type __syscall_slong_t = ::std::os::raw::c_long;
+    pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+    pub type __loff_t = root::__off64_t;
+    pub type __caddr_t = *mut ::std::os::raw::c_char;
+    pub type __intptr_t = ::std::os::raw::c_long;
+    pub type __socklen_t = ::std::os::raw::c_uint;
+    pub type __sig_atomic_t = ::std::os::raw::c_int;
+    pub type int_least8_t = root::__int_least8_t;
+    pub type int_least16_t = root::__int_least16_t;
+    pub type int_least32_t = root::__int_least32_t;
+    pub type int_least64_t = root::__int_least64_t;
+    pub type uint_least8_t = root::__uint_least8_t;
+    pub type uint_least16_t = root::__uint_least16_t;
+    pub type uint_least32_t = root::__uint_least32_t;
+    pub type uint_least64_t = root::__uint_least64_t;
     pub type int_fast8_t = ::std::os::raw::c_schar;
     pub type int_fast16_t = ::std::os::raw::c_long;
     pub type int_fast32_t = ::std::os::raw::c_long;
@@ -354,8 +458,8 @@ pub mod root {
     pub type uint_fast16_t = ::std::os::raw::c_ulong;
     pub type uint_fast32_t = ::std::os::raw::c_ulong;
     pub type uint_fast64_t = ::std::os::raw::c_ulong;
-    pub type intmax_t = ::std::os::raw::c_long;
-    pub type uintmax_t = ::std::os::raw::c_ulong;
+    pub type intmax_t = root::__intmax_t;
+    pub type uintmax_t = root::__uintmax_t;
     pub mod DB {
         #[allow(unused_imports)]
         use self::super::super::root;
@@ -700,11 +804,7 @@ pub mod root {
             pub fn_check_http_uri_available:
                 ::std::option::Option<unsafe extern "C" fn(arg1: root::DB::BaseBuffView) -> u8>,
             pub fn_gc_raw_cpp_ptr: ::std::option::Option<
-                unsafe extern "C" fn(
-                    arg1: *mut root::DB::EngineStoreServerWrap,
-                    arg2: root::DB::RawVoidPtr,
-                    arg3: root::DB::RawCppPtrType,
-                ),
+                unsafe extern "C" fn(arg1: root::DB::RawVoidPtr, arg2: root::DB::RawCppPtrType),
             >,
             pub fn_gen_batch_read_index_res:
                 ::std::option::Option<unsafe extern "C" fn(arg1: u64) -> root::DB::RawVoidPtr>,
@@ -719,7 +819,7 @@ pub mod root {
                 unsafe extern "C" fn(arg1: root::DB::BaseBuffView, arg2: root::DB::RawVoidPtr),
             >,
         }
-        pub const RAFT_STORE_PROXY_VERSION: u32 = 501001;
+        pub const RAFT_STORE_PROXY_VERSION: u32 = 501002;
         pub const RAFT_STORE_PROXY_MAGIC_NUMBER: u32 = 324508639;
     }
 }

--- a/components/raftstore/src/engine_store_ffi/interfaces.rs
+++ b/components/raftstore/src/engine_store_ffi/interfaces.rs
@@ -713,8 +713,9 @@ pub mod root {
                 unsafe extern "C" fn(
                     arg1: root::DB::RaftStoreProxyPtr,
                     arg2: root::DB::CppStrVecView,
-                    arg3: u64,
-                ) -> root::DB::RawVoidPtr,
+                    arg3: root::DB::RawVoidPtr,
+                    arg4: u64,
+                ),
             >,
             pub sst_reader_interfaces: root::DB::SSTReaderInterfaces,
             pub fn_server_info: ::std::option::Option<
@@ -806,8 +807,6 @@ pub mod root {
             pub fn_gc_raw_cpp_ptr: ::std::option::Option<
                 unsafe extern "C" fn(arg1: root::DB::RawVoidPtr, arg2: root::DB::RawCppPtrType),
             >,
-            pub fn_gen_batch_read_index_res:
-                ::std::option::Option<unsafe extern "C" fn(arg1: u64) -> root::DB::RawVoidPtr>,
             pub fn_insert_batch_read_index_resp: ::std::option::Option<
                 unsafe extern "C" fn(
                     arg1: root::DB::RawVoidPtr,

--- a/components/raftstore/src/engine_store_ffi/mod.rs
+++ b/components/raftstore/src/engine_store_ffi/mod.rs
@@ -585,12 +585,14 @@ pub fn set_server_info_resp(res: BaseBuffView, ptr: RawVoidPtr) {
 
 impl EngineStoreServerHelper {
     fn gc_raw_cpp_ptr(&self, ptr: *mut ::std::os::raw::c_void, tp: RawCppPtrType) {
+        debug_assert!(self.fn_gc_raw_cpp_ptr.is_some());
         unsafe {
             (self.fn_gc_raw_cpp_ptr.into_inner())(ptr, tp);
         }
     }
 
     pub fn handle_compute_store_stats(&self) -> StoreStats {
+        debug_assert!(self.fn_handle_compute_store_stats.is_some());
         unsafe { (self.fn_handle_compute_store_stats.into_inner())(self.inner) }
     }
 
@@ -599,14 +601,17 @@ impl EngineStoreServerHelper {
         cmds: &WriteCmds,
         header: RaftCmdHeader,
     ) -> EngineStoreApplyRes {
+        debug_assert!(self.fn_handle_write_raft_cmd.is_some());
         unsafe { (self.fn_handle_write_raft_cmd.into_inner())(self.inner, cmds.gen_view(), header) }
     }
 
     pub fn handle_get_engine_store_server_status(&self) -> EngineStoreServerStatus {
+        debug_assert!(self.fn_handle_get_engine_store_server_status.is_some());
         unsafe { (self.fn_handle_get_engine_store_server_status.into_inner())(self.inner) }
     }
 
     pub fn handle_set_proxy(&self, proxy: *const RaftStoreProxyFFIHelper) {
+        debug_assert!(self.fn_atomic_update_proxy.is_some());
         unsafe { (self.fn_atomic_update_proxy.into_inner())(self.inner, proxy as *mut _) }
     }
 
@@ -634,6 +639,7 @@ impl EngineStoreServerHelper {
         resp: &raft_cmdpb::AdminResponse,
         header: RaftCmdHeader,
     ) -> EngineStoreApplyRes {
+        debug_assert!(self.fn_handle_admin_raft_cmd.is_some());
         unsafe {
             let req = ProtoMsgBaseBuff::new(req);
             let resp = ProtoMsgBaseBuff::new(resp);
@@ -656,6 +662,7 @@ impl EngineStoreServerHelper {
         index: u64,
         term: u64,
     ) -> RawCppPtr {
+        debug_assert!(self.fn_pre_handle_snapshot.is_some());
         let snaps_view = into_sst_views(snaps);
         unsafe {
             let region = ProtoMsgBaseBuff::new(region);
@@ -671,6 +678,7 @@ impl EngineStoreServerHelper {
     }
 
     pub fn apply_pre_handled_snapshot(&self, snap: RawCppPtr) {
+        debug_assert!(self.fn_apply_pre_handled_snapshot.is_some());
         unsafe {
             (self.fn_apply_pre_handled_snapshot.into_inner())(self.inner, snap.ptr, snap.type_)
         }
@@ -681,6 +689,7 @@ impl EngineStoreServerHelper {
         snaps: Vec<(&[u8], ColumnFamilyType)>,
         header: RaftCmdHeader,
     ) -> EngineStoreApplyRes {
+        debug_assert!(self.fn_handle_ingest_sst.is_some());
         let snaps_view = into_sst_views(snaps);
         unsafe {
             (self.fn_handle_ingest_sst.into_inner())(
@@ -692,16 +701,19 @@ impl EngineStoreServerHelper {
     }
 
     pub fn handle_destroy(&self, region_id: u64) {
+        debug_assert!(self.fn_handle_destroy.is_some());
         unsafe {
             (self.fn_handle_destroy.into_inner())(self.inner, region_id);
         }
     }
 
     pub fn handle_check_terminated(&self) -> bool {
+        debug_assert!(self.fn_handle_check_terminated.is_some());
         unsafe { (self.fn_handle_check_terminated.into_inner())(self.inner) != 0 }
     }
 
     fn gen_cpp_string(&self, buff: &[u8]) -> RawCppStringPtr {
+        debug_assert!(self.fn_gen_cpp_string.is_some());
         unsafe { (self.fn_gen_cpp_string.into_inner())(buff.into()).into_raw() as RawCppStringPtr }
     }
 
@@ -711,6 +723,7 @@ impl EngineStoreServerHelper {
         r: &kvrpcpb::ReadIndexResponse,
         region_id: u64,
     ) {
+        debug_assert!(self.fn_insert_batch_read_index_resp.is_some());
         let r = ProtoMsgBaseBuff::new(r);
         unsafe {
             (self.fn_insert_batch_read_index_resp.into_inner())(
@@ -722,14 +735,17 @@ impl EngineStoreServerHelper {
     }
 
     pub fn handle_http_request(&self, path: &str) -> HttpRequestRes {
+        debug_assert!(self.fn_handle_http_request.is_some());
         unsafe { (self.fn_handle_http_request.into_inner())(self.inner, path.as_bytes().into()) }
     }
 
     pub fn check_http_uri_available(&self, path: &str) -> bool {
+        debug_assert!(self.fn_check_http_uri_available.is_some());
         unsafe { (self.fn_check_http_uri_available.into_inner())(path.as_bytes().into()) != 0 }
     }
 
     pub fn set_server_info_resp(&self, res: BaseBuffView, ptr: RawVoidPtr) {
+        debug_assert!(self.fn_set_server_info_resp.is_some());
         unsafe { (self.fn_set_server_info_resp.into_inner())(res, ptr) }
     }
 }

--- a/components/raftstore/src/engine_store_ffi/mod.rs
+++ b/components/raftstore/src/engine_store_ffi/mod.rs
@@ -538,10 +538,17 @@ impl Drop for RawCppPtr {
     }
 }
 
-static mut ENGINE_STORE_SERVER_HELPER_PTR: u64 = 0;
+static mut ENGINE_STORE_SERVER_HELPER_PTR: isize = 0;
 
-pub fn get_engine_store_server_helper() -> &'static EngineStoreServerHelper {
-    unsafe { &(*(ENGINE_STORE_SERVER_HELPER_PTR as *const EngineStoreServerHelper)) }
+fn get_engine_store_server_helper() -> &'static EngineStoreServerHelper {
+    gen_engine_store_server_helper(unsafe { ENGINE_STORE_SERVER_HELPER_PTR })
+}
+
+pub fn gen_engine_store_server_helper(
+    engine_store_server_helper: isize,
+) -> &'static EngineStoreServerHelper {
+    debug_assert!(engine_store_server_helper != 0);
+    unsafe { &(*(engine_store_server_helper as *const EngineStoreServerHelper)) }
 }
 
 /// # Safety
@@ -569,6 +576,12 @@ impl From<Pin<&Vec<SSTView>>> for SSTViewVec {
             len: snaps_view.len() as u64,
         }
     }
+}
+
+unsafe impl Sync for EngineStoreServerHelper {}
+
+pub fn set_server_info_resp(res: BaseBuffView, ptr: RawVoidPtr) {
+    get_engine_store_server_helper().set_server_info_resp(res, ptr)
 }
 
 impl EngineStoreServerHelper {

--- a/components/raftstore/src/engine_store_ffi/mod.rs
+++ b/components/raftstore/src/engine_store_ffi/mod.rs
@@ -112,8 +112,9 @@ pub extern "C" fn ffi_encryption_method(
 pub extern "C" fn ffi_batch_read_index(
     proxy_ptr: RaftStoreProxyPtr,
     view: CppStrVecView,
+    res: RawVoidPtr,
     timeout_ms: u64,
-) -> RawVoidPtr {
+) {
     assert!(!proxy_ptr.is_null());
     if view.len != 0 {
         assert_ne!(view.view, std::ptr::null());
@@ -132,12 +133,10 @@ pub extern "C" fn ffi_batch_read_index(
             .as_ref()
             .read_index_client
             .batch_read_index(req_vec, Duration::from_millis(timeout_ms));
-        let res = get_engine_store_server_helper().gen_batch_read_index_res(resp.len() as u64);
         assert_ne!(res, std::ptr::null_mut());
         for (r, region_id) in &resp {
             get_engine_store_server_helper().insert_batch_read_index_resp(res, r, *region_id);
         }
-        res
     }
 }
 
@@ -704,10 +703,6 @@ impl EngineStoreServerHelper {
 
     fn gen_cpp_string(&self, buff: &[u8]) -> RawCppStringPtr {
         unsafe { (self.fn_gen_cpp_string.into_inner())(buff.into()).into_raw() as RawCppStringPtr }
-    }
-
-    fn gen_batch_read_index_res(&self, cap: u64) -> RawVoidPtr {
-        unsafe { (self.fn_gen_batch_read_index_res.into_inner())(cap) }
     }
 
     fn insert_batch_read_index_resp(

--- a/components/raftstore/src/engine_store_ffi/mod.rs
+++ b/components/raftstore/src/engine_store_ffi/mod.rs
@@ -587,7 +587,7 @@ pub fn set_server_info_resp(res: BaseBuffView, ptr: RawVoidPtr) {
 impl EngineStoreServerHelper {
     fn gc_raw_cpp_ptr(&self, ptr: *mut ::std::os::raw::c_void, tp: RawCppPtrType) {
         unsafe {
-            (self.fn_gc_raw_cpp_ptr.into_inner())(self.inner, ptr, tp);
+            (self.fn_gc_raw_cpp_ptr.into_inner())(ptr, tp);
         }
     }
 

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -32,6 +32,9 @@ with_prefix!(prefix_store "store-");
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
+    #[online_config(skip)]
+    pub engine_store_server_helper: isize,
+
     // minimizes disruption when a partitioned node rejoins the cluster by using a two phase election.
     #[online_config(skip)]
     pub prevote: bool,
@@ -205,6 +208,7 @@ impl Default for Config {
     fn default() -> Config {
         let split_size = ReadableSize::mb(coprocessor::config::SPLIT_SIZE_MB);
         Config {
+            engine_store_server_helper: 0,
             prevote: true,
             raftdb_path: String::new(),
             capacity: ReadableSize(0),

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -40,7 +40,6 @@ use txn_types::WriteBatchFlags;
 
 use self::memtrace::*;
 use crate::coprocessor::RegionChangeEvent;
-use crate::engine_store_ffi::get_engine_store_server_helper;
 use crate::store::cmd_resp::{bind_term, new_error};
 use crate::store::fsm::store::{PollContext, StoreMeta};
 use crate::store::fsm::{
@@ -1961,8 +1960,11 @@ where
         self.fsm.peer.pending_remove = true;
 
         {
-            // hacked by solotzg
-            get_engine_store_server_helper().handle_destroy(region_id);
+            let engine_store_server_helper =
+                crate::engine_store_ffi::gen_engine_store_server_helper(
+                    self.ctx.cfg.engine_store_server_helper,
+                );
+            engine_store_server_helper.handle_destroy(region_id);
         }
 
         let mut meta = self.ctx.store_meta.lock().unwrap();

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1231,9 +1231,9 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
         };
         mgr.init()?;
         let region_runner = RegionRunner::new(
+            &*cfg.value(),
             engines.kv.clone(),
             mgr.clone(),
-            cfg.value().snap_handle_pool_size,
             cfg.value().region_worker_tick_interval,
             cfg.value().use_delete_range,
             workers.coprocessor_host.clone(),
@@ -1376,6 +1376,7 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             .spawn("apply".to_owned(), apply_poller_builder);
 
         let pd_runner = PdRunner::new(
+            &cfg,
             store.get_id(),
             Arc::clone(&pd_client),
             self.router.clone(),

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -391,6 +391,7 @@ impl LockCFFileReader {
 impl Snapshot {
     pub fn pre_handle_snapshot(
         &self,
+        engine_store_server_helper: &'static crate::engine_store_ffi::EngineStoreServerHelper,
         region: &kvproto::metapb::Region,
         peer_id: u64,
         index: u64,
@@ -413,7 +414,7 @@ impl Snapshot {
             ));
         }
 
-        let res = engine_store_ffi::get_engine_store_server_helper()
+        let res = engine_store_server_helper
             .pre_handle_snapshot(&region, peer_id, sst_views, index, term);
 
         PreHandledSnapshot {

--- a/components/server/src/util.rs
+++ b/components/server/src/util.rs
@@ -1,14 +1,12 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+use futures::compat::Future01CompatExt;
+use futures::executor::block_on;
 use kvproto::diagnosticspb::{ServerInfoRequest, ServerInfoResponse, ServerInfoType};
 use protobuf::Message;
 use raftstore::engine_store_ffi::interfaces::root::DB::{
     BaseBuffView, RaftStoreProxyPtr, RawVoidPtr,
 };
-use raftstore::engine_store_ffi::{get_engine_store_server_helper, ProtoMsgBaseBuff};
-
-use futures::compat::Future01CompatExt;
-use futures::executor::block_on;
 use std::pin::Pin;
 use std::time::{Duration, Instant};
 use tikv::server::service::diagnostics::sys;
@@ -75,7 +73,7 @@ pub extern "C" fn ffi_server_info(
     req.merge_from_bytes(view.to_slice()).unwrap();
 
     let resp = server_info_for_ffi(req);
-    let r = ProtoMsgBaseBuff::new(&resp);
-    get_engine_store_server_helper().set_server_info_resp(Pin::new(&r).into(), res);
+    let r = raftstore::engine_store_ffi::ProtoMsgBaseBuff::new(&resp);
+    raftstore::engine_store_ffi::set_server_info_resp(Pin::new(&r).into(), res);
     0
 }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
@@ -1,4 +1,4 @@
-//5607d49301125704c9ce9f74c12dfc31//501002//
+//6286385a862e63dd3c9186abc90ed5fa//501002//
 #pragma once
 #include <cstdint>
 namespace DB { constexpr uint32_t RAFT_STORE_PROXY_VERSION = 501002; }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
@@ -1,4 +1,4 @@
-//0e0095b0e500d4b94f4ee8962689b8de//501001//
+//5607d49301125704c9ce9f74c12dfc31//501002//
 #pragma once
 #include <cstdint>
-namespace DB { constexpr uint32_t RAFT_STORE_PROXY_VERSION = 501001; }
+namespace DB { constexpr uint32_t RAFT_STORE_PROXY_VERSION = 501002; }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
@@ -169,7 +169,7 @@ struct EngineStoreServerHelper {
   HttpRequestRes (*fn_handle_http_request)(EngineStoreServerWrap *,
                                            BaseBuffView);
   uint8_t (*fn_check_http_uri_available)(BaseBuffView);
-  void (*fn_gc_raw_cpp_ptr)(EngineStoreServerWrap *, RawVoidPtr, RawCppPtrType);
+  void (*fn_gc_raw_cpp_ptr)(RawVoidPtr, RawCppPtrType);
   RawVoidPtr (*fn_gen_batch_read_index_res)(uint64_t);
   void (*fn_insert_batch_read_index_resp)(RawVoidPtr, BaseBuffView, uint64_t);
   void (*fn_set_server_info_resp)(BaseBuffView, RawVoidPtr);

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
@@ -133,8 +133,8 @@ struct RaftStoreProxyFFIHelper {
                                                  BaseBuffView);
   FileEncryptionInfoRaw (*fn_handle_link_file)(RaftStoreProxyPtr, BaseBuffView,
                                                BaseBuffView);
-  RawVoidPtr (*fn_handle_batch_read_index)(RaftStoreProxyPtr, CppStrVecView,
-                                           uint64_t);
+  void (*fn_handle_batch_read_index)(RaftStoreProxyPtr, CppStrVecView,
+                                     RawVoidPtr, uint64_t);
   SSTReaderInterfaces sst_reader_interfaces;
 
   uint32_t (*fn_server_info)(RaftStoreProxyPtr, BaseBuffView, RawVoidPtr);
@@ -170,7 +170,6 @@ struct EngineStoreServerHelper {
                                            BaseBuffView);
   uint8_t (*fn_check_http_uri_available)(BaseBuffView);
   void (*fn_gc_raw_cpp_ptr)(RawVoidPtr, RawCppPtrType);
-  RawVoidPtr (*fn_gen_batch_read_index_res)(uint64_t);
   void (*fn_insert_batch_read_index_resp)(RawVoidPtr, BaseBuffView, uint64_t);
   void (*fn_set_server_info_resp)(BaseBuffView, RawVoidPtr);
 };


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

For now, there are only one `ENGINE_STORE_SERVER_HELPER_PTR` and the whole program reply on it. So we can NOT simulate a cluster with more than one nodes.

### What is changed and how it works?

* set engine_store_server_helper for related modules
* optimize interfaces

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```