### PR TITLE
keep the default values of 'addr' and 'status_addr' consistent with tiup

### DIFF
--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -19,7 +19,7 @@ pub use raftstore::store::Config as RaftStoreConfig;
 use super::snap::Task as SnapTask;
 
 pub const DEFAULT_CLUSTER_ID: u64 = 0;
-pub const DEFAULT_LISTENING_ADDR: &str = "127.0.0.1:20106";
+pub const DEFAULT_LISTENING_ADDR: &str = "127.0.0.1:20170";
 pub const DEFAULT_ENGINE_ADDR: &str = if cfg!(feature = "failpoints") {
     "127.0.0.1:20206"
 } else {
@@ -27,7 +27,7 @@ pub const DEFAULT_ENGINE_ADDR: &str = if cfg!(feature = "failpoints") {
 };
 
 const DEFAULT_ADVERTISE_LISTENING_ADDR: &str = "";
-const DEFAULT_STATUS_ADDR: &str = "127.0.0.1:20108";
+const DEFAULT_STATUS_ADDR: &str = "127.0.0.1:20292";
 const DEFAULT_GRPC_CONCURRENCY: usize = 5;
 const DEFAULT_GRPC_CONCURRENT_STREAM: i32 = 1024;
 const DEFAULT_GRPC_RAFT_CONN_NUM: usize = 1;


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/pingcap/tics/issues/3538

### What is changed and how it works?

What's Changed:

keep the default values of 'addr' and 'status_addr' consistent with [tiup](https://github.com/pingcap/tiup/blob/2afffedb1f79119d5e728d2cbec405e4443dd1f6/pkg/cluster/spec/tiflash.go#L52-L53) and the [doc](https://docs.pingcap.com/zh/tidb/stable/hardware-and-software-requirements#%E7%BD%91%E7%BB%9C%E8%A6%81%E6%B1%82).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```