### PR TITLE
modify default config `apply-max-batch-size` and `snap-handle-pool-size` 

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -247,7 +247,7 @@ impl Default for Config {
             peer_stale_state_check_interval: ReadableDuration::minutes(5),
             leader_transfer_max_log_lag: 128,
             snap_apply_batch_size: ReadableSize::mb(10),
-            snap_handle_pool_size: 4,
+            snap_handle_pool_size: 2,
             region_worker_tick_interval: ReadableDuration::millis(500),
             lock_cf_compact_interval: ReadableDuration::minutes(10),
             lock_cf_compact_bytes_threshold: ReadableSize::mb(256),
@@ -428,7 +428,7 @@ impl Config {
                 return Err(box_err!("apply-max-batch-size should be greater than 0"));
             }
         } else {
-            self.apply_batch_system.max_batch_size = Some(512);
+            self.apply_batch_system.max_batch_size = Some(256);
         }
         if self.store_batch_system.pool_size == 0 {
             return Err(box_err!("store-pool-size should be greater than 0"));


### PR DESCRIPTION
### What problem does this PR solve?
pingcap/tics#3412
### What is changed and how it works?
Revert modification of the default value of config `apply-max-batch-size` and `snap-handle-pool-size` in this [PR](https://github.com/pingcap/tidb-engine-ext/pull/36) to avoid untested risk.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
 Check the value of  config `apply-max-batch-size` and `snap-handle-pool-size` in `last_tikv.toml`.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
