### PR TITLE
add ffi function `fn_get_region_peer_state` to get peer state of a region

### DIFF
--- a/components/raftstore/src/engine_store_ffi/interfaces.rs
+++ b/components/raftstore/src/engine_store_ffi/interfaces.rs
@@ -266,6 +266,9 @@ pub mod root {
                     arg3: root::DB::RawVoidPtr,
                 ) -> u32,
             >,
+            pub fn_get_region_peer_state: ::std::option::Option<
+                unsafe extern "C" fn(arg1: root::DB::RaftStoreProxyPtr, region_id: u64) -> i32,
+            >,
         }
         #[repr(C)]
         #[derive(Debug)]
@@ -370,7 +373,7 @@ pub mod root {
                 ),
             >,
         }
-        pub const RAFT_STORE_PROXY_VERSION: u64 = 2676036121052655811;
+        pub const RAFT_STORE_PROXY_VERSION: u64 = 11139201650575501933;
         pub const RAFT_STORE_PROXY_MAGIC_NUMBER: u32 = 324508639;
     }
 }

--- a/components/raftstore/src/engine_store_ffi/interfaces.rs
+++ b/components/raftstore/src/engine_store_ffi/interfaces.rs
@@ -267,7 +267,11 @@ pub mod root {
                 ) -> u32,
             >,
             pub fn_get_region_peer_state: ::std::option::Option<
-                unsafe extern "C" fn(arg1: root::DB::RaftStoreProxyPtr, region_id: u64) -> i32,
+                unsafe extern "C" fn(
+                    arg1: root::DB::RaftStoreProxyPtr,
+                    region_id: u64,
+                    arg2: *mut i32,
+                ) -> u8,
             >,
         }
         #[repr(C)]
@@ -373,7 +377,7 @@ pub mod root {
                 ),
             >,
         }
-        pub const RAFT_STORE_PROXY_VERSION: u64 = 11139201650575501933;
+        pub const RAFT_STORE_PROXY_VERSION: u64 = 5622458399296350332;
         pub const RAFT_STORE_PROXY_MAGIC_NUMBER: u32 = 324508639;
     }
 }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -146,6 +146,7 @@ pub unsafe fn run_tikv(config: TiKvConfig, engine_store_server_helper: &EngineSt
                     tikv.router.clone(),
                     SysQuota::cpu_cores_quota() as usize * 2,
                 )),
+                kv_engine: None,
             };
 
             let proxy_helper = {
@@ -177,6 +178,7 @@ pub unsafe fn run_tikv(config: TiKvConfig, engine_store_server_helper: &EngineSt
             let (engines, engines_info) = tikv.init_raw_engines(Some(limiter.clone()));
             limiter.set_low_priority_io_adjustor_if_needed(Some(engines_info.clone()));
             tikv.init_engines(engines.clone());
+            proxy.kv_engine = Some(engines.kv.clone());
             let server_config = tikv.init_servers();
             tikv.register_services();
             tikv.init_metrics_flusher(fetcher, engines_info);

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -284,6 +284,7 @@ impl<T: Simulator> Cluster<T> {
                 router.clone(),
                 SysQuota::cpu_cores_quota() as usize * 2,
             )),
+            kv_engine: Some(engines.kv.clone()),
         });
 
         let mut proxy_helper = Box::new(raftstore::engine_store_ffi::RaftStoreProxyFFIHelper::new(

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
@@ -1,3 +1,3 @@
 #pragma once
 #include <cstdint>
-namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 2676036121052655811ull; }
+namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 11139201650575501933ull; }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
@@ -1,3 +1,3 @@
 #pragma once
 #include <cstdint>
-namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 11139201650575501933ull; }
+namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 5622458399296350332ull; }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
@@ -141,6 +141,7 @@ struct RaftStoreProxyFFIHelper {
   SSTReaderInterfaces sst_reader_interfaces;
 
   uint32_t (*fn_server_info)(RaftStoreProxyPtr, BaseBuffView, RawVoidPtr);
+  int32_t (*fn_get_region_peer_state)(RaftStoreProxyPtr, uint64_t region_id);
 };
 
 struct EngineStoreServerHelper {

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
@@ -141,7 +141,8 @@ struct RaftStoreProxyFFIHelper {
   SSTReaderInterfaces sst_reader_interfaces;
 
   uint32_t (*fn_server_info)(RaftStoreProxyPtr, BaseBuffView, RawVoidPtr);
-  int32_t (*fn_get_region_peer_state)(RaftStoreProxyPtr, uint64_t region_id);
+  uint8_t (*fn_get_region_peer_state)(RaftStoreProxyPtr, uint64_t region_id,
+                                      int32_t *);
 };
 
 struct EngineStoreServerHelper {

--- a/tests/failpoints/cases/test_normal.rs
+++ b/tests/failpoints/cases/test_normal.rs
@@ -29,7 +29,12 @@ fn test_normal() {
     unsafe {
         for (k, ffi_set) in cluster.ffi_helper_set.iter() {
             let f = ffi_set.proxy_helper.fn_get_region_peer_state.unwrap();
-            assert_eq!(f(ffi_set.proxy_helper.proxy_ptr.clone(), region_id), 0);
+            let mut r = 0;
+            assert_eq!(
+                f(ffi_set.proxy_helper.proxy_ptr.clone(), region_id, &mut r),
+                1
+            );
+            assert_eq!(r, 0);
         }
     }
 

--- a/tests/failpoints/cases/test_normal.rs
+++ b/tests/failpoints/cases/test_normal.rs
@@ -27,7 +27,7 @@ fn test_normal() {
     }
     let region_id = cluster.get_region(k).get_id();
     unsafe {
-        for (k, ffi_set) in cluster.ffi_helper_set.iter() {
+        for (_, ffi_set) in cluster.ffi_helper_set.iter() {
             let f = ffi_set.proxy_helper.fn_get_region_peer_state.unwrap();
             let mut r = 0;
             assert_eq!(

--- a/tests/failpoints/cases/test_normal.rs
+++ b/tests/failpoints/cases/test_normal.rs
@@ -16,7 +16,7 @@ fn test_normal() {
     }
 
     // Try to start this node, return after persisted some keys.
-    let result = cluster.start();
+    let _ = cluster.start();
 
     let k = b"k1";
     let v = b"v1";
@@ -24,6 +24,13 @@ fn test_normal() {
     for id in cluster.engines.keys() {
         must_get_equal(&cluster.get_engine(*id), k, v);
         // must_get_equal(db, k, v);
+    }
+    let region_id = cluster.get_region(k).get_id();
+    unsafe {
+        for (k, ffi_set) in cluster.ffi_helper_set.iter() {
+            let f = ffi_set.proxy_helper.fn_get_region_peer_state.unwrap();
+            assert_eq!(f(ffi_set.proxy_helper.proxy_ptr.clone(), region_id), 0);
+        }
     }
 
     cluster.shutdown();


### PR DESCRIPTION
Signed-off-by: CalvinNeo <calvinneo1995@gmail.com>

### What problem does this PR solve?

Problem Summary:

This PR aims to find a better way to solve [tics#3435](https://github.com/pingcap/tics/issues/3435), by enabling TiFlash to get region state from proxy.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
add ffi function fn_get_region_peer_state to get peer state of a region
```
