### PR TITLE
pprof: ignore cpu profiling on non-x86 arch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,6 @@ pd_client = { path = "components/pd_client", default-features = false }
 pin-project = "1.0"
 pnet_datalink = "0.23"
 prost = "0.7"
-pprof = { version = "^0.6", default-features = false, features = ["flamegraph", "protobuf", "cpp"] }
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }
 raftstore = { path = "components/raftstore", default-features = false }
@@ -227,6 +226,9 @@ walkdir = "2"
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 resource_metering = { path = "components/resource_metering" }
 seahash = "4.1.0"
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+pprof = { version = "^0.6", default-features = false, features = ["flamegraph", "protobuf", "cpp"] }
 
 [dev-dependencies]
 example_plugin = { path = "components/test_coprocessor_plugin/example_plugin" } # should be a binary dependency

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -28,6 +28,7 @@ use openssl::ssl::{
 };
 use openssl::x509::X509;
 use pin_project::pin_project;
+#[cfg(target_arch = "x86_64")]
 use pprof::protos::Message;
 use raftstore::store::{transport::CasualRouter, CasualMessage};
 use regex::Regex;
@@ -113,6 +114,7 @@ pub struct StatusServer<E, R> {
 }
 
 impl StatusServer<(), ()> {
+    #[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
     fn extract_thread_name(thread_name: &str) -> String {
         lazy_static! {
             static ref THREAD_NAME_RE: Regex =
@@ -132,6 +134,7 @@ impl StatusServer<(), ()> {
             .unwrap_or_else(|| thread_name.to_owned())
     }
 
+    #[cfg(target_arch = "x86_64")]
     fn frames_post_processor() -> impl Fn(&mut pprof::Frames) {
         move |frames| {
             let name = Self::extract_thread_name(&frames.thread_name);
@@ -340,6 +343,7 @@ where
         })
     }
 
+    #[cfg(target_arch = "x86_64")]
     pub async fn dump_rsprof(seconds: u64, frequency: i32) -> pprof::Result<pprof::Report> {
         let guard = pprof::ProfilerGuardBuilder::default()
             .frequency(frequency)
@@ -357,6 +361,7 @@ where
             .build()
     }
 
+    #[cfg(target_arch = "x86_64")]
     pub async fn dump_rsperf_to_resp(req: Request<Body>) -> hyper::Result<Response<Body>> {
         let query = match req.uri().query() {
             Some(query) => query,
@@ -433,6 +438,18 @@ where
                 )),
             }
         }
+    }
+
+    /// Currently, on aarch64 architectures, the underlying libgcc/llvm-libunwind/... which pprof-rs
+    /// depends on has a segmentation fault (when backtracking happens in the signal handler).
+    /// So, for now, we only allow the x86_64 architecture to perform real profiling, other
+    /// architectures will directly return an error until we fix the seg-fault in backtrace.
+    #[cfg(not(target_arch = "x86_64"))]
+    pub async fn dump_rsperf_to_resp(req: Request<Body>) -> hyper::Result<Response<Body>> {
+        Ok(StatusServer::err_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "unsupported arch".to_string(),
+        ))
     }
 
     async fn change_log_level(req: Request<Body>) -> hyper::Result<Response<Body>> {
@@ -1550,6 +1567,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_arch = "x86_64")]
     fn test_pprof_profile_service() {
         let mut status_server = StatusServer::new(
             1,
@@ -1625,3 +1643,4 @@ mod tests {
         status_server.stop();
     }
 }
+

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -445,7 +445,7 @@ where
     /// So, for now, we only allow the x86_64 architecture to perform real profiling, other
     /// architectures will directly return an error until we fix the seg-fault in backtrace.
     #[cfg(not(target_arch = "x86_64"))]
-    pub async fn dump_rsperf_to_resp(req: Request<Body>) -> hyper::Result<Response<Body>> {
+    pub async fn dump_rsperf_to_resp(_req: Request<Body>) -> hyper::Result<Response<Body>> {
         Ok(StatusServer::err_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "unsupported arch".to_string(),
@@ -1643,4 +1643,3 @@ mod tests {
         status_server.stop();
     }
 }
-


### PR DESCRIPTION
### What is changed and how it works?

Make CPU Profiling only happen on x86_64 to avoid crashes. This is a temporary workaround, we're still working on fixing crashes in libgcc/llvm-libunwind/...

### Release note

```release-note
Prevent TiKV segment fault (but produce an error) when profiling in ARM.
```
