### PR TITLE
Fix openssl to be 1.1

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -9,7 +9,7 @@ if [[ $(uname -s) == "Darwin" ]]; then
   echo ""
   target_path="target/release"
   mkdir -p "${target_path}"
-  OPENSSL_ROOT_DIR=$(brew --prefix openssl) OPENSSL_NO_VENDOR=1 OPENSSL_STATIC=1 PROXY_LIB_TARGET_COPY_PATH="${target_path}/lib${ENGINE_LABEL_VALUE}_proxy.dylib" make debug
+  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) OPENSSL_NO_VENDOR=1 OPENSSL_STATIC=1 PROXY_LIB_TARGET_COPY_PATH="${target_path}/lib${ENGINE_LABEL_VALUE}_proxy.dylib" make debug
 else
   export PROXY_BUILD_TYPE=release
   export PROXY_PROFILE=release


### PR DESCRIPTION
### What problem does this PR solve?

Homebrew on our CI machine is 3.3.5, and uses openssl@3 by default, but openssl@3 is not installed at all.

### What is changed and how it works?

Fix the openssl version to be 1.1 in our `brew --prefix` command, so we keep using openssl@1.1 in our build script.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
