### PR TITLE
Cherry pick: raftstore: set term when catch up logs for merge  (#11545)

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3458,7 +3458,7 @@ where
         ctx: &mut ApplyContext<EK, W>,
         catch_up_logs: CatchUpLogs,
     ) {
-        fail_point!("after_handle_catch_up_logs_for_merge");
+        fail_point!("after_handle_catch_up_logs_for_merge", |_| {});
         fail_point!(
             "after_handle_catch_up_logs_for_merge_1003",
             self.delegate.id() == 1003,

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -1364,3 +1364,61 @@ fn test_prewrite_before_max_ts_is_synced() {
     let resp = do_prewrite(&mut cluster);
     assert!(!resp.get_region_error().has_max_timestamp_not_synced());
 }
+
+/// If term is changed in catching up logs, follower needs to update the term
+/// correctly, otherwise will leave corrupted states.
+#[test]
+fn test_merge_election_and_restart() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_merge(&mut cluster);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let on_raft_gc_log_tick_fp = "on_raft_gc_log_tick";
+    fail::cfg(on_raft_gc_log_tick_fp, "return()").unwrap();
+
+    cluster.run();
+
+    let region = pd_client.get_region(b"k1").unwrap();
+    cluster.must_split(&region, b"k2");
+
+    let r1 = pd_client.get_region(b"k1").unwrap();
+    let r1_on_store1 = find_peer(&r1, 1).unwrap().to_owned();
+    cluster.must_transfer_leader(r1.get_id(), r1_on_store1.clone());
+    cluster.must_put(b"k11", b"v11");
+    must_get_equal(&cluster.get_engine(2), b"k11", b"v11");
+
+    let r1_on_store2 = find_peer(&r1, 2).unwrap().to_owned();
+    cluster.must_transfer_leader(r1.get_id(), r1_on_store2);
+    cluster.must_put(b"k12", b"v12");
+    must_get_equal(&cluster.get_engine(1), b"k12", b"v12");
+
+    cluster.add_send_filter(CloneFilterFactory(RegionPacketFilter::new(r1.get_id(), 2)));
+
+    // Wait new leader elected.
+    cluster.must_transfer_leader(r1.get_id(), r1_on_store1);
+    cluster.must_put(b"k13", b"v13");
+    must_get_equal(&cluster.get_engine(1), b"k13", b"v13");
+    must_get_none(&cluster.get_engine(2), b"k13");
+
+    // Don't actually execute commit merge
+    fail::cfg("after_handle_catch_up_logs_for_merge", "return()").unwrap();
+    // Now region 1 can still be merged into region 2 because leader has committed index cache.
+    let r2 = pd_client.get_region(b"k3").unwrap();
+    cluster.must_try_merge(r1.get_id(), r2.get_id());
+    // r1 on store 2 should be able to apply all committed logs.
+    must_get_equal(&cluster.get_engine(2), b"k13", b"v13");
+
+    cluster.shutdown();
+    cluster.clear_send_filters();
+    fail::remove("after_handle_catch_up_logs_for_merge");
+    cluster.start().unwrap();
+
+    // Wait for region elected to avoid timeout and backoff.
+    cluster.leader_of_region(r2.get_id());
+    // If merge can be resumed correctly, the put should succeed.
+    cluster.must_put(b"k14", b"v14");
+    // If logs from different term are process correctly, store 2 should have latest updates.
+    must_get_equal(&cluster.get_engine(2), b"k14", b"v14");
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close [#4437](https://github.com/pingcap/tiflash/issues/4437).

Problem Summary:

Cherry pick [fd24cc9e3b43f77f0dceba5bf20f7b4f9e9dae44](https://github.com/tikv/tikv/commit/fd24cc9e3b43f77f0dceba5bf20f7b4f9e9dae44)

Issue: https://github.com/tikv/tikv/issues/11526

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
