### PR TITLE
Fix build when openssl v1.1 and v3 both installed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ lib_suffix="so"
 if [[ $(uname -s) == "Darwin" ]]; then
   lib_suffix="dylib"
   # use the openssl 1.1 lib from system
-  export OPENSSL_DIR=${OPENSSL_ROOT_DIR:-$(brew --prefix openssl@1.1)}
+  export OPENSSL_DIR=${OPENSSL_DIR:-$(brew --prefix openssl@1.1)}
 
   if [[ -z ${OPENSSL_DIR} ]]; then
     echo "Not found openssl installed by Homebrew or env 'OPENSSL_DIR', please install openssl by 'brew install openssl@1.1'"

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,8 @@ lib_suffix="so"
 if [[ $(uname -s) == "Darwin" ]]; then
   lib_suffix="dylib"
   # use the openssl 1.1 lib from system
-  export OPENSSL_DIR=${OPENSSL_DIR:-$(brew --prefix openssl@1.1)}
+  export OPENSSL_DIR=${OPENSSL_DIR:-$(brew --prefix openssl@1.1)}  # for openssl-sys
+  export OPENSSL_ROOT_DIR=${OPENSSL_DIR}  # for Cmake
 
   if [[ -z ${OPENSSL_DIR} ]]; then
     echo "Not found openssl installed by Homebrew or env 'OPENSSL_DIR', please install openssl by 'brew install openssl@1.1'"
@@ -20,11 +21,11 @@ if [[ $(uname -s) == "Darwin" ]]; then
   fi
 
   echo "OPENSSL_DIR: ${OPENSSL_DIR}"
-  export OPENSSL_NO_VENDOR=1
-  export OPENSSL_STATIC=1
+  export OPENSSL_NO_VENDOR=1  # for openssl-sys
+  export OPENSSL_STATIC=1     # for openssl-sys
 fi
 
-PROXY_ENABLE_FEATURES=${PROXY_ENABLE_FEATURES} ./cargo-build.sh
+CFLAGS=-w CXXFLAGS=-w PROXY_ENABLE_FEATURES=${PROXY_ENABLE_FEATURES} ./cargo-build.sh
 
 target_name="lib${ENGINE_LABEL_VALUE}_proxy.${lib_suffix}"
 ori_build_path="target/${PROXY_PROFILE}/libraftstore_proxy.${lib_suffix}"

--- a/build.sh
+++ b/build.sh
@@ -12,14 +12,14 @@ lib_suffix="so"
 if [[ $(uname -s) == "Darwin" ]]; then
   lib_suffix="dylib"
   # use the openssl 1.1 lib from system
-  export OPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR:-$(brew --prefix openssl@1.1)}
+  export OPENSSL_DIR=${OPENSSL_ROOT_DIR:-$(brew --prefix openssl@1.1)}
 
-  if [[ -z ${OPENSSL_ROOT_DIR} ]]; then
-    echo "Not found openssl installed by Homebrew or env 'OPENSSL_ROOT_DIR', please install openssl by 'brew install openssl@1.1'"
+  if [[ -z ${OPENSSL_DIR} ]]; then
+    echo "Not found openssl installed by Homebrew or env 'OPENSSL_DIR', please install openssl by 'brew install openssl@1.1'"
     exit -1
   fi
-  
-  echo "OPENSSL_ROOT_DIR: ${OPENSSL_ROOT_DIR}"
+
+  echo "OPENSSL_DIR: ${OPENSSL_DIR}"
   export OPENSSL_NO_VENDOR=1
   export OPENSSL_STATIC=1
 fi


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Fix build on MacOS M1 when openssl@1.1 and openssl@3 are both installed.

Previously env variable are just not set, falling into the default library search behavior of openssl-sys:

- In TiKV v5.4 branch, openssl-sys will [find openssl@1.1](https://github.com/sfackler/rust-openssl/blob/aeafacbf2436f13720730744d9f890123534fbdb/openssl-sys/build/find_normal.rs#L29).

- In TiKV v6.0 branch, openssl-sys will [find openssl@3](https://github.com/sfackler/rust-openssl/blob/e76289f6addb9e5e11f640c590ae13a0b87dc557/openssl-sys/build/find_normal.rs#L36) first.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
