### PR TITLE
Enable frame pointer

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,18 @@ echo "profile is ${PROXY_PROFILE}"
 echo "engine is ${ENGINE_LABEL_VALUE}"
 echo "prometheus metric name prefix is ${PROMETHEUS_METRIC_NAME_PREFIX}"
 
+if [[ -n "${PROXY_FRAME_POINTER}" && "${PROXY_FRAME_POINTER}" != 0 ]]; then
+  echo "frame pointer is enabled"
+else
+  echo "frame pointer is disabled"
+fi
+
+if [[ -n "${PROXY_BUILD_STD}" && "${PROXY_BUILD_STD}" != 0 ]]; then
+  echo "rust build-std is enabled"
+else
+  echo "rust build-std is disabled"
+fi
+
 lib_suffix="so"
 if [[ $(uname -s) == "Darwin" ]]; then
   lib_suffix="dylib"

--- a/cargo-build.sh
+++ b/cargo-build.sh
@@ -7,4 +7,9 @@ fi
 
 set -ex
 
-cargo build --no-default-features --features "${PROXY_ENABLE_FEATURES}" ${cargo_build_extra_parameter}
+if [[ -n "${PROXY_BUILD_STD}" && "${PROXY_BUILD_STD}" != "0" ]]; then
+  rustup component add rust-src
+  cargo build --no-default-features --features "${PROXY_ENABLE_FEATURES}" ${cargo_build_extra_parameter} ${PROXY_BUILD_STD_ARGS}
+else
+  cargo build --no-default-features --features "${PROXY_ENABLE_FEATURES}" ${cargo_build_extra_parameter}
+fi

--- a/debug.sh
+++ b/debug.sh
@@ -5,4 +5,14 @@ set -e
 export CARGO_PROFILE_DEV_DEBUG="true"
 export CARGO_PROFILE_RELEASE_DEBUG="true"
 
+if [[ -n "${PROXY_BUILD_STD}" && "${PROXY_BUILD_STD}" != "0" ]]; then
+    # When `-Z build-std` is enabled, `--target` must be specified explicitly,
+    # and specifying `--target` will cause the generated binary to be located
+    # in the `target/${TARGET}/release` directory instead of `target/release`,
+    # so we need to explicitly specify `--out-dir` here, to avoid errors when
+    # copying the output binary later.
+    export PROXY_BUILD_STD_ARGS="-Z build-std=core,std,alloc,proc_macro,test --target=${PROXY_BUILD_RUSTC_TARGET}"
+    export PROXY_BUILD_STD_ARGS="${PROXY_BUILD_STD_ARGS} -Z unstable-options --out-dir=target/debug"
+fi
+
 make build

--- a/release.sh
+++ b/release.sh
@@ -13,5 +13,16 @@ if [[ $(uname -s) == "Darwin" ]]; then
 else
   export PROXY_BUILD_TYPE=release
   export PROXY_PROFILE=release
+
+  if [[ -n "${PROXY_BUILD_STD}" && "${PROXY_BUILD_STD}" != "0" ]]; then
+      # When `-Z build-std` is enabled, `--target` must be specified explicitly,
+      # and specifying `--target` will cause the generated binary to be located
+      # in the `target/${TARGET}/release` directory instead of `target/release`,
+      # so we need to explicitly specify `--out-dir` here, to avoid errors when
+      # copying the output binary later.
+      export PROXY_BUILD_STD_ARGS="-Z build-std=core,std,alloc,proc_macro,test --target=${PROXY_BUILD_RUSTC_TARGET}"
+      export PROXY_BUILD_STD_ARGS="${PROXY_BUILD_STD_ARGS} -Z unstable-options --out-dir=target/release"
+  fi
+
   make build
 fi


### PR DESCRIPTION
### What's changed

Update `Makefile` and other build scripts to enable frame pointer & re-compile Rust std.

### Details

The stack backtrace implementation of `pprof-rs` which we currently depends on is based on `libunwind`, which may trigger segmentation faults in some scenarios (especially on ARM architecture).

Here are some related issues:

- https://github.com/tikv/tikv/issues/10658
- https://github.com/tikv/tikv/issues/9957
- https://github.com/tikv/tikv/issues/11964

This PR prepares for the introduction of a new version of `pprof-rs`. The new `pprof-rs` provides frame-pointer-based stack backtrace.

> More tech info is in https://github.com/tikv/tikv/pull/12326 maintained by @YangKeao.

### Performance overhead

Enabling the frame pointer will use the `RBP/x29` register to hold the frame address, one less general purpose register means there may be a performance regression.

Here is a simple [measurement](https://github.com/tikv/pprof-rs/pull/116#issuecomment-1102156557). In general, the frame-pointer-based stack backtrace has no performance regression compared to the original DWARF-based stack backtrace.

In other words, for scenes with CPU Profiling (or Continuous Profiling) enabled, the overall overhead based on frame pointers is much lower than that based on DWARF. But for scenes that don't use profiling, there is a little extra overhead at all times for frame pointers.

### Default behavior and manual control

There are now two additional environment variables that control compilation behavior: `PROXY_FRAME_POINTER` and `PROXY_BUILD_STD`. We set them all to `1` by default in the `Makefile`, which means they are enabled by default.

If you want to disable frame-pointer, please manually set the environment variable `PROXY_FRAME_POINTER=0 make` (this will cause CPU Profiling to get only the top function and not the full call stack after we upgrade `pprof-rs`).

If you want to avoid recompiling the Rust standard library, please manually set the environment variable `PROXY_BUILD_STD=0 make` (this will lose CPU Profiling samples related to Rust std functions after we upgrade `pprof-rs`).

If you avoid run `make` and just use `cargo build`, the frame pointer will not be enabled and std will not be recompiled.

### Release note

```release-note
None
```
