### PR TITLE
Enable CPU Profiling on ARM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,17 +32,6 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "ahash"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796540673305a66d127804eef19ad696f1f204b8c1025aaca4958c17eab32877"
-dependencies = [
- "getrandom 0.2.3",
- "once_cell",
- "version_check 0.9.2",
-]
-
-[[package]]
-name = "ahash"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
@@ -978,7 +967,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.4",
  "ryu",
  "serde",
 ]
@@ -1921,7 +1910,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
 dependencies = [
- "ahash 0.7.4",
+ "ahash",
 ]
 
 [[package]]
@@ -1972,7 +1961,7 @@ checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 0.4.4",
 ]
 
 [[package]]
@@ -2019,7 +2008,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.4",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2088,14 +2077,14 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.10.5"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fb405dbcc505ed20838c4f8dad7b901094de90add237755df54bd5dcda2fdd"
+checksum = "16d4bde3a7105e59c66a4104cfe9606453af1c7a0eac78cb7d5bc263eb762a70"
 dependencies = [
- "ahash 0.6.3",
+ "ahash",
  "atty",
  "indexmap",
- "itoa",
+ "itoa 1.0.1",
  "lazy_static",
  "log",
  "num-format",
@@ -2191,6 +2180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "jobserver"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,9 +2254,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libloading"
@@ -2654,6 +2649,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,7 +2759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
 dependencies = [
  "arrayvec",
- "itoa",
+ "itoa 0.4.4",
 ]
 
 [[package]]
@@ -3165,8 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.6.2"
-source = "git+https://github.com/tikv/pprof-rs.git#400456e3e3fa93e88589cb1569c0036051575e05"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9307de92566887d485ac6f20df17b0fe1704fffdbad0bdbc05a3864d3082f6"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -3174,7 +3181,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix 0.23.0",
+ "nix 0.24.1",
  "once_cell",
  "parking_lot 0.12.0",
  "protobuf",
@@ -3366,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
 dependencies = [
  "memchr",
 ]
@@ -4204,7 +4211,7 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
- "itoa",
+ "itoa 0.4.4",
  "ryu",
  "serde",
 ]
@@ -4225,7 +4232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.4",
  "ryu",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ pd_client = { path = "components/pd_client", default-features = false }
 case_macros = {path = "components/case_macros"}
 pin-project = "1.0"
 pnet_datalink = "0.23"
+pprof = { version = "^0.9", default-features = false, features = ["flamegraph", "protobuf-codec", "protobuf", "cpp", "frame-pointer"] }
 prost = "0.7"
 protobuf = { version = "2.8", features = ["bytes"] }
 raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
@@ -164,9 +165,6 @@ yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 resource_metering = { path = "components/resource_metering" }
 seahash = "4.1.0"
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
-pprof = { version = "^0.6", default-features = false, features = ["flamegraph", "protobuf-codec", "protobuf", "cpp"] }
-
 [dev-dependencies]
 example_plugin = { path = "components/test_coprocessor_plugin/example_plugin" } # should be a binary dependency
 panic_hook = { path = "components/panic_hook" }
@@ -185,7 +183,6 @@ raft = { git = "https://github.com/tikv/raft-rs", branch = "master" }
 raft-proto = { git = "https://github.com/tikv/raft-rs", branch = "master" }
 protobuf = { git = "https://github.com/pingcap/rust-protobuf", branch = "v2.8" }
 protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", branch = "v2.8" }
-pprof = { git = "https://github.com/tikv/pprof-rs.git" }
 
 # TODO: remove this replacement after rusoto_s3 truly supports virtual-host style (https://github.com/rusoto/rusoto/pull/1823).
 rusoto_core = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr-styles" }

--- a/src/server/status_server/profile.rs
+++ b/src/server/status_server/profile.rs
@@ -16,7 +16,6 @@ use futures::future::BoxFuture;
 use futures::task::{Context, Poll};
 use futures::{select, Future, FutureExt, Stream, StreamExt};
 use lazy_static::lazy_static;
-#[cfg(target_arch = "x86_64")]
 use pprof::protos::Message;
 use regex::Regex;
 use tempfile::{NamedTempFile, TempDir};
@@ -173,24 +172,7 @@ pub fn deactivate_heap_profile() -> bool {
     activate.take().is_some()
 }
 
-/// Currently, on aarch64 architectures, the underlying libgcc/llvm-libunwind/... which pprof-rs
-/// depends on has a segmentation fault (when backtracking happens in the signal handler).
-/// So, for now, we only allow the x86_64 architecture to perform real profiling, other
-/// architectures will directly return an error until we fix the seg-fault in backtrace.
-#[cfg(not(target_arch = "x86_64"))]
-pub async fn start_one_cpu_profile<F>(
-    _end: F,
-    _frequency: i32,
-    _protobuf: bool,
-) -> Result<Vec<u8>, String>
-where
-    F: Future<Output = Result<(), String>> + Send + 'static,
-{
-    Err("unsupported arch".to_string())
-}
-
 /// Trigger one cpu profile.
-#[cfg(target_arch = "x86_64")]
 pub async fn start_one_cpu_profile<F>(
     end: F,
     frequency: i32,
@@ -300,7 +282,6 @@ where
     Ok(())
 }
 
-#[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
 fn extract_thread_name(thread_name: &str) -> String {
     THREAD_NAME_RE
         .captures(thread_name)
@@ -327,9 +308,11 @@ mod test_utils {
     pub fn activate_prof() -> ProfResult<()> {
         Ok(())
     }
+
     pub fn deactivate_prof() -> ProfResult<()> {
         Ok(())
     }
+
     pub fn dump_prof(_: &str) -> ProfResult<()> {
         Ok(())
     }
@@ -373,7 +356,6 @@ mod tests {
 
     // Test there is at most 1 concurrent profiling.
     #[test]
-    #[cfg(target_arch = "x86_64")]
     fn test_profile_guard_concurrency() {
         use futures::channel::oneshot;
         use futures::TryFutureExt;


### PR DESCRIPTION
Signed-off-by: mornyx <mornyx.z@gmail.com>

### What's changed

After https://github.com/pingcap/tidb-engine-ext/pull/60, we can safely do frame-pointer-based CPU Profiling on ARM without worrying about segfaults now. This PR upgrades `pprof-rs` and again allows tidb-engine-ext to perform CPU Profiling on ARM architectures.

### Release note

```release-note
None
```
