### PR TITLE
merge libsymbolization into raftstore-proxy as a feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3536,6 +3536,9 @@ dependencies = [
 name = "raftstore-proxy"
 version = "0.0.1"
 dependencies = [
+ "backtrace",
+ "findshlibs",
+ "lazy_static",
  "server",
 ]
 

--- a/raftstore-proxy/Cargo.toml
+++ b/raftstore-proxy/Cargo.toml
@@ -9,5 +9,11 @@ publish = false
 name = "raftstore_proxy"
 crate-type = ["cdylib"]
 
+[features]
+symbolization = ["backtrace", "findshlibs", "lazy_static"] # provides symbolization utilities
+
 [dependencies]
 server = { path = "../components/server" }
+backtrace = { version = "0.3", optional = true }
+findshlibs = { version = "0.10", optional = true }
+lazy_static = { version = "1.4", optional = true }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/Symbolization.h
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/Symbolization.h
@@ -1,0 +1,33 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+#include <cstddef>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct SymbolInfo {
+  const char* symbol_name;
+  const char* object_name;
+  const char* source_filename;
+  size_t source_filename_length;
+  size_t lineno;
+  size_t svma;
+};
+
+SymbolInfo _tiflash_symbolize(void* avma);
+
+#ifdef __cplusplus
+}
+#endif

--- a/raftstore-proxy/src/lib.rs
+++ b/raftstore-proxy/src/lib.rs
@@ -46,7 +46,7 @@ pub struct SymbolInfo {
     /// source line number.
     pub lineno: usize,
     /// symbol offset to the beginning of the binary file.
-    pub svma: usize
+    pub svma: usize,
 }
 
 #[cfg(feature = "symbolization")]
@@ -67,27 +67,22 @@ impl Default for SymbolInfo {
 impl SymbolInfo {
     pub fn new(avma: *mut c_void) -> Self {
         let mut info = SymbolInfo::default();
-        if let Some(LocationInObject {name, svma}) = locate_symbol_in_object(avma) {
+        if let Some(LocationInObject { name, svma }) = locate_symbol_in_object(avma) {
             info.object_name = name;
             info.svma = svma;
         }
         backtrace::resolve(avma, |sym| {
             info.symbol_name = sym
                 .name()
-                .map(|x|x.as_bytes().as_ptr() as *const _)
+                .map(|x| x.as_bytes().as_ptr() as *const _)
                 .unwrap_or_else(std::ptr::null);
-            if let Some(src) = sym
-                .filename()
-                .and_then(|x|x.to_str()) {
+            if let Some(src) = sym.filename().and_then(|x| x.to_str()) {
                 info.source_filename = src.as_ptr() as _;
                 info.source_filename_length = src.len();
             }
-            info.lineno = sym.lineno()
-                .map(|x| x as _)
-                .unwrap_or(0)
+            info.lineno = sym.lineno().map(|x| x as _).unwrap_or(0)
         });
         info
-
     }
 }
 

--- a/raftstore-proxy/src/lib.rs
+++ b/raftstore-proxy/src/lib.rs
@@ -1,7 +1,13 @@
+#[cfg(feature = "symbolization")]
+mod object;
+#[cfg(feature = "symbolization")]
+use object::{locate_symbol_in_object, LocationInObject};
+#[cfg(feature = "symbolization")]
+use std::os::raw::c_void;
 use std::os::raw::{c_char, c_int};
 
 /// # Safety
-/// Print version infomatin to std output.
+/// Print version information to std output.
 #[no_mangle]
 pub unsafe extern "C" fn print_raftstore_proxy_version() {
     server::print_proxy_version();
@@ -16,4 +22,84 @@ pub unsafe extern "C" fn run_raftstore_proxy_ffi(
     helper: *const u8,
 ) {
     server::run_proxy(argc, argv, helper);
+}
+
+/// Address Symbolization
+/// Refer [this document](https://docs.rs/findshlibs/latest/findshlibs/#addresses) for explanations
+/// of what is AVMA, SVMA, BIAS.
+/// ------------------------------------------------------------------------------------------------
+/// We pass raw pointers in `SymbolInfo`.
+/// The assumption is that `backtrace` will resolve symbols to image maps (mmap of binary files).
+/// These maps have static life-time.
+#[cfg(feature = "symbolization")]
+#[repr(C)]
+pub struct SymbolInfo {
+    /// corresponding function name
+    pub symbol_name: *const c_char,
+    /// binary file containing the symbol
+    pub object_name: *const c_char,
+    /// filename of the source.
+    pub source_filename: *const c_char,
+    /// length of source filename.
+    /// this is needed because source filename may not have terminate nul.
+    pub source_filename_length: usize,
+    /// source line number.
+    pub lineno: usize,
+    /// symbol offset to the beginning of the binary file.
+    pub svma: usize
+}
+
+#[cfg(feature = "symbolization")]
+impl Default for SymbolInfo {
+    fn default() -> Self {
+        SymbolInfo {
+            symbol_name: std::ptr::null(),
+            object_name: std::ptr::null(),
+            source_filename: std::ptr::null(),
+            source_filename_length: 0,
+            lineno: 0,
+            svma: 0,
+        }
+    }
+}
+
+#[cfg(feature = "symbolization")]
+impl SymbolInfo {
+    pub fn new(avma: *mut c_void) -> Self {
+        let mut info = SymbolInfo::default();
+        if let Some(LocationInObject {name, svma}) = locate_symbol_in_object(avma) {
+            info.object_name = name;
+            info.svma = svma;
+        }
+        backtrace::resolve(avma, |sym| {
+            info.symbol_name = sym
+                .name()
+                .map(|x|x.as_bytes().as_ptr() as *const _)
+                .unwrap_or_else(std::ptr::null);
+            if let Some(src) = sym
+                .filename()
+                .and_then(|x|x.to_str()) {
+                info.source_filename = src.as_ptr() as _;
+                info.source_filename_length = src.len();
+            }
+            info.lineno = sym.lineno()
+                .map(|x| x as _)
+                .unwrap_or(0)
+        });
+        info
+
+    }
+}
+
+/// # Safety
+/// `_tiflash_symbolize` is thread-safe. However, one should avoid reentrancy.
+///
+/// # Note
+/// `_tiflash_symbolize` starts with `_`, indicating that this function is designed for internal
+/// usage. Make sure you understand the mechanism behind this function before put it into your code!
+
+#[cfg(feature = "symbolization")]
+#[no_mangle]
+pub unsafe extern "C" fn _tiflash_symbolize(avma: *mut c_void) -> SymbolInfo {
+    SymbolInfo::new(avma)
 }

--- a/raftstore-proxy/src/object.rs
+++ b/raftstore-proxy/src/object.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use findshlibs::{SharedLibrary, TargetSharedLibrary};
+use lazy_static::lazy_static;
 use std::ffi::{c_void, CString};
 use std::os::raw::c_char;
 use std::os::unix::ffi::OsStringExt;
-use lazy_static::lazy_static;
-use findshlibs::{SharedLibrary, TargetSharedLibrary};
 
 struct CachedObject {
     filename: CString,
@@ -63,17 +63,14 @@ fn init_object_cache() -> Vec<CachedObject> {
 }
 
 lazy_static! {
-    static ref CACHED_OBJECTS : Vec<CachedObject> = init_object_cache();
+    static ref CACHED_OBJECTS: Vec<CachedObject> = init_object_cache();
 }
 
 pub fn locate_symbol_in_object(avma: *const c_void) -> Option<LocationInObject> {
     let address = avma as usize;
     let key = std::cmp::Reverse(address);
-    let obj = match CACHED_OBJECTS
-        .binary_search_by_key(&key, |obj| std::cmp::Reverse(obj.avma)) {
-        Ok(idx) | Err(idx) => {
-            CACHED_OBJECTS.get(idx)
-        }
+    let obj = match CACHED_OBJECTS.binary_search_by_key(&key, |obj| std::cmp::Reverse(obj.avma)) {
+        Ok(idx) | Err(idx) => CACHED_OBJECTS.get(idx),
     };
     obj.and_then(|x| x.locate(address))
 }

--- a/raftstore-proxy/src/object.rs
+++ b/raftstore-proxy/src/object.rs
@@ -1,0 +1,79 @@
+// Copyright 2022 PingCAP, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::{c_void, CString};
+use std::os::raw::c_char;
+use std::os::unix::ffi::OsStringExt;
+use lazy_static::lazy_static;
+use findshlibs::{SharedLibrary, TargetSharedLibrary};
+
+struct CachedObject {
+    filename: CString,
+    avma: usize,
+    size: usize,
+    bias: usize,
+}
+
+pub struct LocationInObject {
+    pub name: *const c_char,
+    pub svma: usize,
+}
+
+impl CachedObject {
+    fn contains(&self, avma: usize) -> bool {
+        self.avma <= avma && self.avma + self.size > avma
+    }
+
+    fn locate(&self, avma: usize) -> Option<LocationInObject> {
+        if self.contains(avma) {
+            Some(LocationInObject {
+                name: self.filename.as_ptr() as _,
+                svma: avma - self.bias,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+fn init_object_cache() -> Vec<CachedObject> {
+    let mut cache = Vec::new();
+    TargetSharedLibrary::each(|obj| {
+        let raw_data = obj.name().to_os_string().into_vec();
+        cache.push(CachedObject {
+            filename: unsafe { CString::from_vec_unchecked(raw_data) },
+            avma: obj.actual_load_addr().0,
+            size: obj.len(),
+            bias: obj.virtual_memory_bias().0,
+        });
+    });
+    cache.sort_by_key(|obj| std::cmp::Reverse(obj.avma));
+    cache
+}
+
+lazy_static! {
+    static ref CACHED_OBJECTS : Vec<CachedObject> = init_object_cache();
+}
+
+pub fn locate_symbol_in_object(avma: *const c_void) -> Option<LocationInObject> {
+    let address = avma as usize;
+    let key = std::cmp::Reverse(address);
+    let obj = match CACHED_OBJECTS
+        .binary_search_by_key(&key, |obj| std::cmp::Reverse(obj.avma)) {
+        Ok(idx) | Err(idx) => {
+            CACHED_OBJECTS.get(idx)
+        }
+    };
+    obj.and_then(|x| x.locate(address))
+}


### PR DESCRIPTION
Signed-off-by: Schrodinger ZHU Yifan <i@zhuyi.fan>

### What problem does this PR solve?

 - `libsymbolization` and `raftstore-proxy` both contains rust runtime objects when compiled as static libraries, which introduce extra symbol conflicts.
 - `libsymbolization` is a rust library in a C++ repo and it has its own toolchain file. This introduces extra effect for maintenance.

### Why a feature?

Otherwise the exported symbols may conflict with existing ones in `libsymbolization.a` and we would have to bump them together to get the whole project compiled. This avoid possible breakage, we mark `libsymbolization` as a feature.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
