### PR TITLE
introduce only-decryption mode

### DIFF
--- a/components/server/src/proxy.rs
+++ b/components/server/src/proxy.rs
@@ -201,6 +201,11 @@ pub unsafe fn run_proxy(
                 .required(true)
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("only-decryption")
+                .long("only-decryption")
+                .help("Only do decryption in Proxy"),
+        )
         .get_matches_from(args);
 
     if matches.is_present("print-sample-config") {
@@ -245,7 +250,11 @@ pub unsafe fn run_proxy(
     }
 
     config.raft_store.engine_store_server_helper = engine_store_server_helper as *const _ as isize;
-    crate::server::run_tikv(config, engine_store_server_helper);
+    if matches.is_present("only-decryption") {
+        crate::server::run_tikv_only_decryption(config, engine_store_server_helper);
+    } else {
+        crate::server::run_tikv(config, engine_store_server_helper);
+    }
 }
 
 fn check_engine_label(matches: &clap::ArgMatches<'_>) {

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -320,10 +320,10 @@ impl<T: Simulator> Cluster<T> {
         let proxy = Box::new(raftstore::engine_store_ffi::RaftStoreProxy::new(
             AtomicU8::new(raftstore::engine_store_ffi::RaftProxyStatus::Idle as u8),
             key_mgr.clone(),
-            Box::new(raftstore::engine_store_ffi::ReadIndexClient::new(
+            Some(Box::new(raftstore::engine_store_ffi::ReadIndexClient::new(
                 router.clone(),
                 SysQuota::cpu_cores_quota() as usize * 2,
-            )),
+            ))),
             std::sync::RwLock::new(Some(engines.kv.clone())),
         ));
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/5122

Problem Summary:

### What is changed and how it works?
TiFlash Proxy introduce `only-decryption` mode. If TiFlash set `--only-decryption`, TiFlash Proxy will not startup TiKV server.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
` ./bin/tiflash/tiflash pagectl -V 3 -P /data2/chentongli/tidb-data/tiflash-19111/page/meta -I 0 --config_file_path conf/tiflash.toml `
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
