### PR TITLE
Re-enable debug service

### DIFF
--- a/components/proxy_server/src/run.rs
+++ b/components/proxy_server/src/run.rs
@@ -1282,23 +1282,22 @@ impl<ER: RaftEngine> TiKvServer<ER> {
         }
 
         // Debug service.
-        // TODO(tiflash) make this usable when tikv merged.
-        // let debug_service = DebugService::new(
-        //     Engines {
-        //         kv: engines.engines.kv.rocks.clone(),
-        //         raft: engines.engines.raft.clone(),
-        //     },
-        //     servers.server.get_debug_thread_pool().clone(),
-        //     self.router.clone(),
-        //     self.cfg_controller.as_ref().unwrap().clone(),
-        // );
-        // if servers
-        //     .server
-        //     .register_service(create_debug(debug_service))
-        //     .is_some()
-        // {
-        //     fatal!("failed to register debug service");
-        // }
+        let debug_service = DebugService::new(
+            Engines {
+                kv: engines.engines.kv.rocks.clone(),
+                raft: engines.engines.raft.clone(),
+            },
+            servers.server.get_debug_thread_pool().clone(),
+            self.router.clone(),
+            self.cfg_controller.as_ref().unwrap().clone(),
+        );
+        if servers
+            .server
+            .register_service(create_debug(debug_service))
+            .is_some()
+        {
+            fatal!("failed to register debug service");
+        }
 
         // Create Diagnostics service
         let diag_service = DiagnosticsService::new(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

Previously, since we use engine_tiflash, DebugService can not be started since it is not paramerized. Since https://github.com/tikv/tikv/commit/fc49bdf8694c629184c2b512ced9390a56641b1a, we can now reopen it.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
