### PR TITLE
Fix error parse of ProxyConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,6 +4146,7 @@ dependencies = [
  "serde_derive",
  "serde_ignored",
  "serde_json",
+ "serde_with",
  "server",
  "signal",
  "slog",

--- a/components/proxy_server/Cargo.toml
+++ b/components/proxy_server/Cargo.toml
@@ -80,6 +80,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_ignored = "0.1"
 serde_json = "1.0"
+serde_with = "1.4"
 server = { path = "../server", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }

--- a/components/proxy_server/src/proxy.rs
+++ b/components/proxy_server/src/proxy.rs
@@ -292,9 +292,11 @@ pub unsafe fn run_proxy(
                 })
             });
     check_engine_label(&matches);
+    // Replace config from `match` from TiFlash's side.
     overwrite_config_with_cmd_args(&mut config, &mut proxy_config, &matches);
     config.logger_compatible_adjust();
 
+    info!("using proxy config"; "config" => ?proxy_config);
     // TODO(tiflash) We should later use ProxyConfig for proxy's own settings like `snap_handle_pool_size`
     if is_config_check {
         validate_and_persist_config(&mut config, false);

--- a/components/proxy_server/src/proxy.rs
+++ b/components/proxy_server/src/proxy.rs
@@ -296,7 +296,6 @@ pub unsafe fn run_proxy(
     overwrite_config_with_cmd_args(&mut config, &mut proxy_config, &matches);
     config.logger_compatible_adjust();
 
-    info!("using proxy config"; "config" => ?proxy_config);
     // TODO(tiflash) We should later use ProxyConfig for proxy's own settings like `snap_handle_pool_size`
     if is_config_check {
         validate_and_persist_config(&mut config, false);

--- a/components/proxy_server/src/run.rs
+++ b/components/proxy_server/src/run.rs
@@ -1081,11 +1081,11 @@ impl<ER: RaftEngine> TiKvServer<ER> {
         let health_service = HealthService::default();
         let mut default_store = kvproto::metapb::Store::default();
 
-        if !self.proxy_config.engine_store_version.is_empty() {
-            default_store.set_version(self.proxy_config.engine_store_version.clone());
+        if !self.proxy_config.server.engine_store_version.is_empty() {
+            default_store.set_version(self.proxy_config.server.engine_store_version.clone());
         }
-        if !self.proxy_config.engine_store_git_hash.is_empty() {
-            default_store.set_git_hash(self.proxy_config.engine_store_git_hash.clone());
+        if !self.proxy_config.server.engine_store_git_hash.is_empty() {
+            default_store.set_git_hash(self.proxy_config.server.engine_store_git_hash.clone());
         }
         // addr -> store.peer_address
         if self.config.server.advertise_addr.is_empty() {
@@ -1094,8 +1094,8 @@ impl<ER: RaftEngine> TiKvServer<ER> {
             default_store.set_peer_address(self.config.server.advertise_addr.clone())
         }
         // engine_addr -> store.addr
-        if !self.proxy_config.engine_addr.is_empty() {
-            default_store.set_address(self.proxy_config.engine_addr.clone());
+        if !self.proxy_config.server.engine_addr.is_empty() {
+            default_store.set_address(self.proxy_config.server.engine_addr.clone());
         } else {
             panic!("engine address is empty");
         }
@@ -1213,7 +1213,7 @@ impl<ER: RaftEngine> TiKvServer<ER> {
             node.id(),
             self.engines.as_ref().unwrap().engines.kv.clone(),
             importer.clone(),
-            self.proxy_config.snap_handle_pool_size,
+            self.proxy_config.raft_store.snap_handle_pool_size,
         );
         tiflash_ob.register_to(self.coprocessor_host.as_mut().unwrap());
 

--- a/components/proxy_server/src/run.rs
+++ b/components/proxy_server/src/run.rs
@@ -522,6 +522,7 @@ impl<ER: RaftEngine> TiKvServer<ER> {
 
         // Initialize and check config
         let cfg_controller = Self::init_config(config);
+        info!("using proxy config"; "config" => ?proxy_config);
         let config = cfg_controller.get_current();
 
         let store_path = Path::new(&config.storage.data_dir).to_owned();

--- a/components/proxy_server/src/setup.rs
+++ b/components/proxy_server/src/setup.rs
@@ -52,21 +52,21 @@ pub fn overwrite_config_with_cmd_args(
     }
 
     if let Some(engine_store_version) = matches.value_of("engine-version") {
-        proxy_config.engine_store_version = engine_store_version.to_owned();
+        proxy_config.server.engine_store_version = engine_store_version.to_owned();
     }
 
     if let Some(engine_store_git_hash) = matches.value_of("engine-git-hash") {
-        proxy_config.engine_store_git_hash = engine_store_git_hash.to_owned();
+        proxy_config.server.engine_store_git_hash = engine_store_git_hash.to_owned();
     }
 
-    if proxy_config.engine_addr.is_empty() {
+    if proxy_config.server.engine_addr.is_empty() {
         if let Some(engine_addr) = matches.value_of("engine-addr") {
-            proxy_config.engine_addr = engine_addr.to_owned();
+            proxy_config.server.engine_addr = engine_addr.to_owned();
         }
     }
 
     if let Some(engine_addr) = matches.value_of("advertise-engine-addr") {
-        proxy_config.engine_addr = engine_addr.to_owned();
+        proxy_config.server.engine_addr = engine_addr.to_owned();
     }
 
     if let Some(data_dir) = matches.value_of("data-dir") {

--- a/new-mock-engine-store/src/mock_cluster.rs
+++ b/new-mock-engine-store/src/mock_cluster.rs
@@ -283,7 +283,7 @@ impl<T: Simulator<TiFlashEngine>> Cluster<T> {
 
         engines.kv.init(
             helper_ptr,
-            self.cfg.proxy_cfg.snap_handle_pool_size,
+            self.cfg.proxy_cfg.raft_store.snap_handle_pool_size,
             Some(ffi_hub),
         );
 

--- a/new-mock-engine-store/src/node.rs
+++ b/new-mock-engine-store/src/node.rs
@@ -300,7 +300,7 @@ impl Simulator<TiFlashEngine> for NodeCluster {
             node_id,
             engines.kv.clone(),
             importer.clone(),
-            cfg.proxy_cfg.snap_handle_pool_size,
+            cfg.proxy_cfg.raft_store.snap_handle_pool_size,
         );
         tiflash_ob.register_to(&mut coprocessor_host);
 


### PR DESCRIPTION
Signed-off-by: CalvinNeo <calvinneo1995@gmail.com>

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/5635

Problem Summary:
ProxyConfig should own submodules: server and raftstore. We can't directly use fields.
See more in issue.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
