### PR TITLE
Don't write to rockdb when meet empty write batch

### DIFF
--- a/engine_tiflash/src/write_batch.rs
+++ b/engine_tiflash/src/write_batch.rs
@@ -103,8 +103,8 @@ impl engine_traits::WriteBatch for RocksWriteBatch {
         let opt: RocksWriteOptions = opts.into();
         self.check_double_write();
         if self.is_empty() {
-            let bt = backtrace::Backtrace::new();
-            info!("abnormal empty write batch";
+            let bt = std::backtrace::Backtrace::capture();
+            tikv_util::info!("abnormal empty write batch";
                 "backtrace" => ?bt
             );
             Ok(())

--- a/engine_tiflash/src/write_batch.rs
+++ b/engine_tiflash/src/write_batch.rs
@@ -102,9 +102,17 @@ impl engine_traits::WriteBatch for RocksWriteBatch {
     fn write_opt(&self, opts: &WriteOptions) -> Result<()> {
         let opt: RocksWriteOptions = opts.into();
         self.check_double_write();
-        self.get_db()
-            .write_opt(&self.wb, &opt.into_raw())
-            .map_err(Error::Engine)
+        if self.is_empty() {
+            let bt = backtrace::Backtrace::new();
+            info!("abnormal empty write batch";
+                "backtrace" => ?bt
+            );
+            Ok(())
+        } else {
+            self.get_db()
+                .write_opt(&self.wb, &opt.into_raw())
+                .map_err(Error::Engine)
+        }
     }
 
     fn data_size(&self) -> usize {


### PR DESCRIPTION
Signed-off-by: CalvinNeo <calvinneo1995@gmail.com>

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/5783

Problem Summary:

There is a vulnerability in TiKV that we may meet deadlock when try to write an empty `WriteBatch` into RocksDB, if `enable_pipelined_write = false`

Aka https://github.com/tikv/rocksdb/pull/312

Though we don't know exactly which codes actually bring about this vulnerability, we can still prevent writes to rocksdb and print out a log trace.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
