### PR TITLE
Fix proxy config

### DIFF
--- a/components/engine_store_ffi/src/observer.rs
+++ b/components/engine_store_ffi/src/observer.rs
@@ -30,7 +30,7 @@ use raftstore::{
     Error, Result,
 };
 use sst_importer::SstImporter;
-use tikv_util::{box_err, debug, error, info, warn};
+use tikv_util::{debug, error, info, warn};
 use yatp::{
     pool::{Builder, ThreadPool},
     task::future::TaskCell,
@@ -40,7 +40,7 @@ use crate::{
     gen_engine_store_server_helper,
     interfaces::root::{DB as ffi_interfaces, DB::EngineStoreApplyRes},
     name_to_cf, ColumnFamilyType, EngineStoreServerHelper, RaftCmdHeader, RawCppPtr, TiFlashEngine,
-    WriteCmdType, WriteCmds, CF_DEFAULT, CF_LOCK, CF_WRITE,
+    WriteCmdType, WriteCmds, CF_LOCK,
 };
 
 impl Into<engine_tiflash::FsStatsExt> for ffi_interfaces::StoreStats {
@@ -732,7 +732,7 @@ impl ApplySnapshotObserver for TiFlashObserver {
                         &snap_key,
                     );
                     match sender.send(res) {
-                        Err(e) => error!("pre apply snapshot err when send to receiver"),
+                        Err(_e) => error!("pre apply snapshot err when send to receiver"),
                         Ok(_) => (),
                     }
                 });

--- a/components/proxy_server/src/config.rs
+++ b/components/proxy_server/src/config.rs
@@ -144,9 +144,11 @@ pub fn make_tikv_config() -> TiKvConfig {
 }
 
 pub fn setup_default_tikv_config(default: &mut TiKvConfig) {
+    // Compact test
     default.server.addr = TIFLASH_DEFAULT_LISTENING_ADDR.to_string();
     default.server.status_addr = TIFLASH_DEFAULT_STATUS_ADDR.to_string();
     default.server.advertise_status_addr = TIFLASH_DEFAULT_STATUS_ADDR.to_string();
+    // Do not add here, try use `address_proxy_config`
 }
 
 /// This function changes TiKV's config according to ProxyConfig.

--- a/components/proxy_server/src/config.rs
+++ b/components/proxy_server/src/config.rs
@@ -147,16 +147,6 @@ pub fn setup_default_tikv_config(default: &mut TiKvConfig) {
     default.server.addr = TIFLASH_DEFAULT_LISTENING_ADDR.to_string();
     default.server.status_addr = TIFLASH_DEFAULT_STATUS_ADDR.to_string();
     default.server.advertise_status_addr = TIFLASH_DEFAULT_STATUS_ADDR.to_string();
-
-    // Unlike TiKV, in TiFlash, we use the low-priority pool to both decode snapshots
-    // (transform from row to column) and ingest SST. These operations are pretty heavy.
-    // So we increase the default limit here to handle ingest SST faster.
-    default.raft_store.apply_batch_system.low_priority_pool_size =
-        (cpu_num * 0.8).clamp(1.0, 8.0) as usize;
-    default.raft_store.region_worker_tick_interval = ReadableDuration::millis(500);
-    let clean_stale_ranges_tick =
-        (10_000 / default.raft_store.region_worker_tick_interval.as_millis()) as usize;
-    default.raft_store.clean_stale_ranges_tick = clean_stale_ranges_tick;
 }
 
 /// This function changes TiKV's config according to ProxyConfig.

--- a/components/proxy_server/src/proxy.rs
+++ b/components/proxy_server/src/proxy.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    ffi::CStr,
+    ffi::{CStr, OsStr},
     os::raw::{c_char, c_int},
     path::Path,
     process,
@@ -10,35 +10,64 @@ use std::{
 use clap::{App, Arg, ArgMatches};
 use tikv::config::TiKvConfig;
 
-use crate::{config::make_tikv_config, fatal, setup::overwrite_config_with_cmd_args};
+use crate::{
+    config::{make_tikv_config, ProxyConfig},
+    fatal,
+    setup::overwrite_config_with_cmd_args,
+};
+
+pub fn gen_proxy_config(
+    config_path: &Option<&OsStr>,
+    is_config_check: bool,
+    proxy_unrecognized_keys: &mut Vec<String>,
+) -> ProxyConfig {
+    // Double read the same file for proxy-specific arguments.
+    let proxy_config = config_path.map_or_else(ProxyConfig::default, |path| {
+        let path = Path::new(path);
+        crate::config::ProxyConfig::from_file(
+            path,
+            if is_config_check {
+                Some(proxy_unrecognized_keys)
+            } else {
+                None
+            },
+        )
+        .unwrap_or_else(|e| {
+            panic!(
+                "invalid auto generated configuration file {}, err {}",
+                path.display(),
+                e
+            );
+        })
+    });
+    proxy_config
+}
 
 /// Generate default TiKvConfig, but with some Proxy's default values.
 pub fn gen_tikv_config(
-    matches: &ArgMatches,
+    config_path: &Option<&OsStr>,
     is_config_check: bool,
     unrecognized_keys: &mut Vec<String>,
 ) -> TiKvConfig {
-    matches
-        .value_of_os("config")
-        .map_or_else(make_tikv_config, |path| {
-            let path = Path::new(path);
-            TiKvConfig::from_file(
-                path,
-                if is_config_check {
-                    Some(unrecognized_keys)
-                } else {
-                    None
-                },
-            )
-            .unwrap_or_else(|e| {
-                error!(
-                    "invalid default auto generated configuration file {}, err {}",
-                    path.display(),
-                    e
-                );
-                std::process::exit(1);
-            })
+    config_path.map_or_else(make_tikv_config, |path| {
+        let path = Path::new(path);
+        TiKvConfig::from_file(
+            path,
+            if is_config_check {
+                Some(unrecognized_keys)
+            } else {
+                None
+            },
+        )
+        .unwrap_or_else(|e| {
+            error!(
+                "invalid default auto generated configuration file {}, err {}",
+                path.display(),
+                e
+            );
+            std::process::exit(1);
         })
+    })
 }
 
 pub unsafe fn run_proxy(
@@ -245,31 +274,12 @@ pub unsafe fn run_proxy(
     let mut unrecognized_keys = Vec::new();
     let is_config_check = matches.is_present("config-check");
 
-    let mut config = gen_tikv_config(&matches, is_config_check, &mut unrecognized_keys);
+    let cpath = matches.value_of_os("config");
+    let mut config = gen_tikv_config(&cpath, is_config_check, &mut unrecognized_keys);
 
     let mut proxy_unrecognized_keys = Vec::new();
-    // Double read the same file for proxy-specific arguments.
-    let mut proxy_config =
-        matches
-            .value_of_os("config")
-            .map_or_else(crate::config::ProxyConfig::default, |path| {
-                let path = Path::new(path);
-                crate::config::ProxyConfig::from_file(
-                    path,
-                    if is_config_check {
-                        Some(&mut proxy_unrecognized_keys)
-                    } else {
-                        None
-                    },
-                )
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "invalid auto generated configuration file {}, err {}",
-                        path.display(),
-                        e
-                    );
-                })
-            });
+    let mut proxy_config = gen_proxy_config(&cpath, is_config_check, &mut proxy_unrecognized_keys);
+
     check_engine_label(&matches);
     // Replace config from `match` from TiFlash's side.
     overwrite_config_with_cmd_args(&mut config, &mut proxy_config, &matches);

--- a/components/proxy_server/src/proxy.rs
+++ b/components/proxy_server/src/proxy.rs
@@ -7,7 +7,7 @@ use std::{
     process,
 };
 
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg};
 use tikv::config::TiKvConfig;
 
 use crate::{
@@ -296,7 +296,7 @@ pub unsafe fn run_proxy(
                 fatal!("unknown configuration options: {}", e);
             }
         }
-        crate::config::address_proxy_config(&mut config);
+        crate::config::address_proxy_config(&mut config, &proxy_config);
         println!("config check successful");
         process::exit(0)
     }

--- a/components/proxy_server/src/run.rs
+++ b/components/proxy_server/src/run.rs
@@ -521,8 +521,8 @@ impl<ER: RaftEngine> TiKvServer<ER> {
             Self::connect_to_pd_cluster(&mut config, env.clone(), Arc::clone(&security_mgr));
 
         // Initialize and check config
-        let cfg_controller = Self::init_config(config);
         info!("using proxy config"; "config" => ?proxy_config);
+        let cfg_controller = Self::init_config(config, &proxy_config);
         let config = cfg_controller.get_current();
 
         let store_path = Path::new(&config.storage.data_dir).to_owned();
@@ -595,10 +595,11 @@ impl<ER: RaftEngine> TiKvServer<ER> {
     /// - If the config can't pass `validate()`
     /// - If the max open file descriptor limit is not high enough to support
     ///   the main database and the raft database.
-    fn init_config(mut config: TiKvConfig) -> ConfigController {
+    fn init_config(mut config: TiKvConfig, proxy_config: &ProxyConfig) -> ConfigController {
         // Add {label: {"engine": "tiflash"}} to Config
-        crate::config::address_proxy_config(&mut config);
+        crate::config::address_proxy_config(&mut config, proxy_config);
         crate::config::validate_and_persist_config(&mut config, true);
+        info!("after address config"; "config" => ?config);
 
         ensure_dir_exist(&config.storage.data_dir).unwrap();
         if !config.rocksdb.wal_dir.is_empty() {

--- a/tests/proxy/normal.rs
+++ b/tests/proxy/normal.rs
@@ -375,10 +375,7 @@ mod config {
             ProxyConfig::default()
                 .raft_store
                 .apply_low_priority_pool_size,
-            config
-                .raft_store
-                .apply_batch_system
-                .low_priority_pool_size
+            config.raft_store.apply_batch_system.low_priority_pool_size
         );
     }
 
@@ -405,10 +402,7 @@ apply-low-priority-pool-size = 41
         // should be used.
         assert_eq!(
             41,
-            config
-                .raft_store
-                .apply_batch_system
-                .low_priority_pool_size
+            config.raft_store.apply_batch_system.low_priority_pool_size
         );
     }
 

--- a/tests/proxy/normal.rs
+++ b/tests/proxy/normal.rs
@@ -296,7 +296,7 @@ mod config {
         let mut unrecognized_keys: Vec<String> = vec![];
         let mut config = TiKvConfig::from_file(path, Some(&mut unrecognized_keys)).unwrap();
         assert_eq!(config.raft_store.clean_stale_ranges_tick, 9999);
-        address_proxy_config(&mut config);
+        address_proxy_config(&mut config, &ProxyConfig::default());
         let clean_stale_ranges_tick =
             (10_000 / config.raft_store.region_worker_tick_interval.as_millis()) as usize;
         assert_eq!(
@@ -323,7 +323,7 @@ mod config {
         let mut config = gen_tikv_config(&None, false, &mut v);
         let mut proxy_config = gen_proxy_config(&None, false, &mut v);
         overwrite_config_with_cmd_args(&mut config, &mut proxy_config, &matches);
-        address_proxy_config(&mut config);
+        address_proxy_config(&mut config, &proxy_config);
 
         assert_eq!(config.server.addr, TIFLASH_DEFAULT_LISTENING_ADDR);
         assert_eq!(config.server.status_addr, TIFLASH_DEFAULT_STATUS_ADDR);
@@ -359,7 +359,7 @@ mod config {
         let mut config = gen_tikv_config(&cpath, false, &mut v);
         let mut proxy_config = gen_proxy_config(&cpath, false, &mut v);
         overwrite_config_with_cmd_args(&mut config, &mut proxy_config, &matches);
-        address_proxy_config(&mut config);
+        address_proxy_config(&mut config, &proxy_config);
 
         assert_eq!(config.rocksdb.max_open_files, 56);
         assert_eq!(config.server.addr, DEFAULT_LISTENING_ADDR);
@@ -376,7 +376,7 @@ mod config {
         let (mut cluster, pd_client) = new_mock_cluster(0, 3);
 
         // Add label to cluster
-        address_proxy_config(&mut cluster.cfg.tikv);
+        address_proxy_config(&mut cluster.cfg.tikv, &ProxyConfig::default());
 
         // Try to start this node, return after persisted some keys.
         let _ = cluster.start();

--- a/tests/proxy/normal.rs
+++ b/tests/proxy/normal.rs
@@ -399,7 +399,6 @@ apply-low-priority-pool-size = 41
         let cpath = Some(path.as_os_str());
         let mut config = gen_tikv_config(&cpath, false, &mut v);
         let mut proxy_config = gen_proxy_config(&cpath, false, &mut v);
-        overwrite_config_with_cmd_args(&mut config, &mut proxy_config, &matches);
         address_proxy_config(&mut config, &proxy_config);
 
         // When raftstore.apply-low-priority-pool-size is specified, its value


### PR DESCRIPTION
Signed-off-by: CalvinNeo <calvinneo1995@gmail.com>

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflash/issues/5170

Problem Summary:

1. gen_tikv_config is useless if we call TiKvConfig::from_file rather than make_tikv_config. We may turn to use address_proxy_config
2. ArgMatches in test can't process `--config`, so it shadows some errors.
3. We refactor some tests.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
