### PR TITLE
use a larger snap pool by default

### DIFF
--- a/components/proxy_server/src/config.rs
+++ b/components/proxy_server/src/config.rs
@@ -33,7 +33,9 @@ impl Default for RaftstoreConfig {
             region_worker_tick_interval: ReadableDuration::millis(500),
             // This pool is used when handling raft Snapshots, e.g. when
             // adding a new TiFlash replica, or scaling TiFlash instances.
-            snap_handle_pool_size: (cpu_num * 0.3).clamp(2.0, 8.0) as usize,
+            // The rate limit is by default controlled by PD scheduling limit,
+            // so it is safe to have a large default here.
+            snap_handle_pool_size: (cpu_num * 0.7).clamp(2.0, 16.0) as usize,
             // This pool is used when handling ingest SST raft messages, e.g.
             // when using BR / lightning.
             apply_low_priority_pool_size: (cpu_num * 0.3).clamp(2.0, 8.0) as usize,


### PR DESCRIPTION
Signed-off-by: Wish <breezewish@outlook.com>

### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

The thread size cannot be adjust online, so we use a larger default, so that it will not be needed to be adjusted in most cases (the real usage will be limited by other configurations anyway).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
