### PR TITLE
Introduce ServerCluster test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,6 +3246,7 @@ name = "new-mock-engine-store"
 version = "0.0.1"
 dependencies = [
  "api_version",
+ "causal_ts",
  "collections",
  "concurrency_manager",
  "crossbeam",
@@ -3259,6 +3260,8 @@ dependencies = [
  "fail",
  "file_system",
  "futures 0.3.15",
+ "grpcio",
+ "grpcio-health",
  "keys",
  "kvproto",
  "lazy_static",
@@ -3269,7 +3272,9 @@ dependencies = [
  "raft",
  "raftstore",
  "rand 0.8.3",
+ "resolved_ts",
  "resource_metering",
+ "security",
  "slog",
  "slog-global",
  "tempfile",
@@ -3278,6 +3283,9 @@ dependencies = [
  "test_util",
  "tikv",
  "tikv_util",
+ "tokio",
+ "tokio-timer",
+ "txn_types",
 ]
 
 [[package]]

--- a/ci_check.sh
+++ b/ci_check.sh
@@ -32,6 +32,7 @@ elif [[ $M == "testnew" ]]; then
     cargo test --package tests --test proxy normal::snapshot
     cargo test --package tests --test proxy normal::restart
     cargo test --package tests --test proxy normal::persist
+    cargo test --package tests --test proxy server_cluster_test
     # tests based on new-mock-engine-store, for some tests not available for new proxy
     cargo test --package tests --test proxy proxy
 elif [[ $M == "debug" ]]; then

--- a/new-mock-engine-store/Cargo.toml
+++ b/new-mock-engine-store/Cargo.toml
@@ -17,6 +17,7 @@ protobuf-codec = [
 
 [dependencies]
 api_version = { path = "../components/api_version", default-features = false }
+causal_ts = { path = "../components/causal_ts" }
 collections = { path = "../components/collections" }
 concurrency_manager = { path = "../components/concurrency_manager", default-features = false }
 crossbeam = "0.8"
@@ -30,6 +31,8 @@ engine_traits = { path = "../components/engine_traits", default-features = false
 fail = "0.5"
 file_system = { path = "../components/file_system", default-features = false }
 futures = { version = "0.3", features = ["thread-pool", "compat"] }
+grpcio = { version = "0.10", default-features = false, features = ["openssl-vendored", "protobuf-codec"] }
+grpcio-health = { version = "0.10", default-features = false, features = ["protobuf-codec"] }
 keys = { path = "../components/keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 
@@ -42,9 +45,8 @@ raft = { version = "0.7.0", default-features = false, features = ["protobuf-code
 raftstore = { path = "../components/raftstore", default-features = false }
 rand = "0.8"
 resolved_ts = { path = "../components/resolved_ts" }
-causal_ts = { path = "../components/causal_ts" }
-security = { path = "../components/security", default-features = false }
 resource_metering = { path = "../components/resource_metering" }
+security = { path = "../components/security", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tempfile = "3.0"
@@ -53,8 +55,6 @@ test_raftstore = { path = "../components/test_raftstore" }
 test_util = { path = "../components/test_util", default-features = false }
 tikv = { path = "../.", default-features = false }
 tikv_util = { path = "../components/tikv_util", default-features = false }
-grpcio = { version = "0.10", default-features = false, features = ["openssl-vendored", "protobuf-codec"] }
-grpcio-health = { version = "0.10", default-features = false, features = ["protobuf-codec"] }
 tokio = { version = "1.5", features = ["rt-multi-thread"] }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 txn_types = { path = "../components/txn_types", default-features = false }

--- a/new-mock-engine-store/Cargo.toml
+++ b/new-mock-engine-store/Cargo.toml
@@ -41,6 +41,9 @@ proxy_server = { path = "../components/proxy_server" }
 raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
 raftstore = { path = "../components/raftstore", default-features = false }
 rand = "0.8"
+resolved_ts = { path = "../components/resolved_ts" }
+causal_ts = { path = "../components/causal_ts" }
+security = { path = "../components/security", default-features = false }
 resource_metering = { path = "../components/resource_metering" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
@@ -50,3 +53,8 @@ test_raftstore = { path = "../components/test_raftstore" }
 test_util = { path = "../components/test_util", default-features = false }
 tikv = { path = "../.", default-features = false }
 tikv_util = { path = "../components/tikv_util", default-features = false }
+grpcio = { version = "0.10", default-features = false, features = ["openssl-vendored", "protobuf-codec"] }
+grpcio-health = { version = "0.10", default-features = false, features = ["protobuf-codec"] }
+tokio = { version = "1.5", features = ["rt-multi-thread"] }
+tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
+txn_types = { path = "../components/txn_types", default-features = false }

--- a/new-mock-engine-store/src/lib.rs
+++ b/new-mock-engine-store/src/lib.rs
@@ -26,13 +26,13 @@ pub use mock_cluster::{
 use protobuf::Message;
 use tikv_util::{debug, error, info, warn};
 
-use crate::config::MockConfig;
+use crate::{config::MockConfig, server::ServerCluster};
 
 pub mod config;
 pub mod mock_cluster;
 pub mod node;
-pub mod transport_simulate;
 pub mod server;
+pub mod transport_simulate;
 
 type RegionId = u64;
 #[derive(Default, Clone)]
@@ -1051,17 +1051,16 @@ pub fn cf_to_name(cf: ffi_interfaces::ColumnFamilyType) -> &'static str {
     }
 }
 
-pub static mut EXPECTED_LEADER_SAFE_TS: u64 = 0;
-pub static mut EXPECTED_SELF_SAFE_TS: u64 = 0;
-
 unsafe extern "C" fn ffi_handle_safe_ts_update(
-    _arg1: *mut ffi_interfaces::EngineStoreServerWrap,
+    arg1: *mut ffi_interfaces::EngineStoreServerWrap,
     _region_id: u64,
     self_safe_ts: u64,
     leader_safe_ts: u64,
 ) {
-    assert_eq!(self_safe_ts, EXPECTED_SELF_SAFE_TS);
-    assert_eq!(leader_safe_ts, EXPECTED_LEADER_SAFE_TS);
+    let store = into_engine_store_server_wrap(arg1);
+    let cluster = store.cluster_ptr as *const mock_cluster::Cluster<ServerCluster>;
+    assert_eq!(self_safe_ts, (*cluster).test_data.expected_self_safe_ts);
+    assert_eq!(leader_safe_ts, (*cluster).test_data.expected_leader_safe_ts);
 }
 
 unsafe extern "C" fn ffi_apply_pre_handled_snapshot(

--- a/new-mock-engine-store/src/lib.rs
+++ b/new-mock-engine-store/src/lib.rs
@@ -32,6 +32,7 @@ pub mod config;
 pub mod mock_cluster;
 pub mod node;
 pub mod transport_simulate;
+pub mod server;
 
 type RegionId = u64;
 #[derive(Default, Clone)]
@@ -660,7 +661,7 @@ pub fn gen_engine_store_server_helper(
         fn_get_config: None,
         fn_set_store: None,
         fn_set_pb_msg_by_bytes: Some(ffi_set_pb_msg_by_bytes),
-        fn_handle_safe_ts_update: None,
+        fn_handle_safe_ts_update: Some(ffi_handle_safe_ts_update),
     }
 }
 
@@ -1048,6 +1049,19 @@ pub fn cf_to_name(cf: ffi_interfaces::ColumnFamilyType) -> &'static str {
         ffi_interfaces::ColumnFamilyType::Default => CF_DEFAULT,
         _ => unreachable!(),
     }
+}
+
+pub static mut EXPECTED_LEADER_SAFE_TS: u64 = 0;
+pub static mut EXPECTED_SELF_SAFE_TS: u64 = 0;
+
+unsafe extern "C" fn ffi_handle_safe_ts_update(
+    _arg1: *mut ffi_interfaces::EngineStoreServerWrap,
+    _region_id: u64,
+    self_safe_ts: u64,
+    leader_safe_ts: u64,
+) {
+    assert_eq!(self_safe_ts, EXPECTED_SELF_SAFE_TS);
+    assert_eq!(leader_safe_ts, EXPECTED_LEADER_SAFE_TS);
 }
 
 unsafe extern "C" fn ffi_apply_pre_handled_snapshot(

--- a/new-mock-engine-store/src/mock_cluster.rs
+++ b/new-mock-engine-store/src/mock_cluster.rs
@@ -21,9 +21,10 @@ use file_system::IoRateLimiter;
 use futures::executor::block_on;
 use kvproto::{
     errorpb::Error as PbError,
+    kvrpcpb::*,
     metapb::{self, PeerRole, RegionEpoch, StoreLabel},
     raft_cmdpb::{RaftCmdRequest, RaftCmdResponse, Request, *},
-    raft_serverpb::RaftMessage, kvrpcpb::*,
+    raft_serverpb::RaftMessage,
 };
 use pd_client::PdClient;
 pub use proxy_server::config::ProxyConfig;
@@ -63,7 +64,7 @@ use tikv_util::{
 pub use crate::config::Config;
 use crate::{
     gen_engine_store_server_helper, transport_simulate::Filter, EngineStoreServer,
-    EngineStoreServerWrap, MockConfig, EXPECTED_LEADER_SAFE_TS, EXPECTED_SELF_SAFE_TS,
+    EngineStoreServerWrap, MockConfig,
 };
 
 pub struct FFIHelperSet {
@@ -80,6 +81,11 @@ pub struct EngineHelperSet {
     pub engine_store_server: Box<EngineStoreServer>,
     pub engine_store_server_wrap: Box<EngineStoreServerWrap>,
     pub engine_store_server_helper: Box<engine_store_ffi::EngineStoreServerHelper>,
+}
+
+pub struct TestData {
+    pub expected_leader_safe_ts: u64,
+    pub expected_self_safe_ts: u64,
 }
 
 pub struct Cluster<T: Simulator<TiFlashEngine>> {
@@ -101,6 +107,7 @@ pub struct Cluster<T: Simulator<TiFlashEngine>> {
     pub group_props: HashMap<u64, GroupProperties>,
     pub sim: Arc<RwLock<T>>,
     pub pd_client: Arc<TestPdClient>,
+    pub test_data: TestData,
 }
 
 impl<T: Simulator<TiFlashEngine>> Cluster<T> {
@@ -139,6 +146,10 @@ impl<T: Simulator<TiFlashEngine>> Cluster<T> {
             group_props: HashMap::default(),
             sim,
             pd_client,
+            test_data: TestData {
+                expected_leader_safe_ts: 0,
+                expected_self_safe_ts: 0,
+            },
         }
     }
 
@@ -370,9 +381,9 @@ impl<T: Simulator<TiFlashEngine>> Cluster<T> {
         Ok(())
     }
 
-    pub unsafe fn set_expected_safe_ts(&mut self, leader_safe_ts: u64, self_safe_ts: u64) {
-        EXPECTED_LEADER_SAFE_TS = leader_safe_ts;
-        EXPECTED_SELF_SAFE_TS = self_safe_ts;
+    pub fn set_expected_safe_ts(&mut self, leader_safe_ts: u64, self_safe_ts: u64) {
+        self.test_data.expected_leader_safe_ts = leader_safe_ts;
+        self.test_data.expected_self_safe_ts = self_safe_ts;
     }
 }
 

--- a/new-mock-engine-store/src/mock_cluster.rs
+++ b/new-mock-engine-store/src/mock_cluster.rs
@@ -23,7 +23,7 @@ use kvproto::{
     errorpb::Error as PbError,
     metapb::{self, PeerRole, RegionEpoch, StoreLabel},
     raft_cmdpb::{RaftCmdRequest, RaftCmdResponse, Request, *},
-    raft_serverpb::RaftMessage,
+    raft_serverpb::RaftMessage, kvrpcpb::*,
 };
 use pd_client::PdClient;
 pub use proxy_server::config::ProxyConfig;
@@ -51,7 +51,7 @@ pub use test_raftstore::{
     new_region_leader_cmd, new_request, new_status_request, new_store, new_tikv_config,
     new_transfer_leader_cmd, sleep_ms,
 };
-use tikv::{config::TikvConfig, server::Result as ServerResult};
+use tikv::{config::TikvConfig, server::Result as ServerResult, storage::mvcc::TimeStamp};
 use tikv_util::{
     debug, error, escape, safe_panic,
     sys::SysQuota,
@@ -63,7 +63,7 @@ use tikv_util::{
 pub use crate::config::Config;
 use crate::{
     gen_engine_store_server_helper, transport_simulate::Filter, EngineStoreServer,
-    EngineStoreServerWrap, MockConfig,
+    EngineStoreServerWrap, MockConfig, EXPECTED_LEADER_SAFE_TS, EXPECTED_SELF_SAFE_TS,
 };
 
 pub struct FFIHelperSet {
@@ -368,6 +368,11 @@ impl<T: Simulator<TiFlashEngine>> Cluster<T> {
             self.associate_ffi_helper_set(None, node_id);
         }
         Ok(())
+    }
+
+    pub unsafe fn set_expected_safe_ts(&mut self, leader_safe_ts: u64, self_safe_ts: u64) {
+        EXPECTED_LEADER_SAFE_TS = leader_safe_ts;
+        EXPECTED_SELF_SAFE_TS = self_safe_ts;
     }
 }
 

--- a/new-mock-engine-store/src/server.rs
+++ b/new-mock-engine-store/src/server.rs
@@ -164,7 +164,8 @@ impl ServerCluster {
         );
         let security_mgr = Arc::new(SecurityManager::new(&Default::default()).unwrap());
         let map = AddressMap::default();
-        // We don't actually need to handle snapshot message, just create a dead worker to make it compile.
+        // We don't actually need to handle snapshot message, just create a dead worker
+        // to make it compile.
         let worker = LazyWorker::new("snap-worker");
         let conn_builder = ConnectionBuilder::new(
             env.clone(),

--- a/new-mock-engine-store/src/server.rs
+++ b/new-mock-engine-store/src/server.rs
@@ -63,21 +63,23 @@ use tikv::{
     storage::{self, kv::SnapContext, txn::flow_controller::FlowController, Engine},
 };
 use tikv_util::{
+    box_err,
     config::VersionTrack,
     quota_limiter::QuotaLimiter,
+    thd_name,
     time::ThreadReadId,
     worker::{Builder as WorkerBuilder, LazyWorker},
-    HandyRwLock, box_err, thd_name,
+    HandyRwLock,
 };
 use tokio::runtime::Builder as TokioBuilder;
+use transport_simulate::SimulateTransport;
 use txn_types::TxnExtraScheduler;
 
 use super::*;
 use crate::config::Config;
 
-use transport_simulate::SimulateTransport;
-
-type SimulateStoreTransport = SimulateTransport<ServerRaftStoreRouter<TiFlashEngine, engine_rocks::RocksEngine>>;
+type SimulateStoreTransport =
+    SimulateTransport<ServerRaftStoreRouter<TiFlashEngine, engine_rocks::RocksEngine>>;
 type SimulateServerTransport =
     SimulateTransport<ServerTransport<SimulateStoreTransport, PdStoreAddrResolver, TiFlashEngine>>;
 
@@ -707,7 +709,10 @@ impl Simulator<TiFlashEngine> for ServerCluster {
             .clear_filters();
     }
 
-    fn get_router(&self, node_id: u64) -> Option<RaftRouter<TiFlashEngine, engine_rocks::RocksEngine>> {
+    fn get_router(
+        &self,
+        node_id: u64,
+    ) -> Option<RaftRouter<TiFlashEngine, engine_rocks::RocksEngine>> {
         self.metas.get(&node_id).map(|m| m.raw_router.clone())
     }
 

--- a/new-mock-engine-store/src/server.rs
+++ b/new-mock-engine-store/src/server.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use api_version::{dispatch_api_version, KvFormat};
-use causal_ts::CausalTsProvider;
+use causal_ts::{tests::DummyRawTsTracker, CausalTsProvider};
 use collections::{HashMap, HashSet};
 use concurrency_manager::ConcurrencyManager;
 use encryption_export::DataKeyManager;
@@ -37,7 +37,7 @@ use raftstore::{
         fsm::{store::StoreMeta, ApplyRouter, RaftBatchSystem, RaftRouter},
         msg::RaftCmdExtraOpts,
         AutoSplitController, Callback, CheckLeaderRunner, LocalReader, RegionSnapshot, SnapManager,
-        SnapManagerBuilder, SplitCheckRunner, SplitConfigManager,
+        SnapManagerBuilder, SplitCheckRunner, SplitConfigManager, StoreMetaDelegate,
     },
     Result,
 };
@@ -60,12 +60,18 @@ use tikv::{
         ConnectionBuilder, Error, Node, PdStoreAddrResolver, RaftClient, RaftKv,
         Result as ServerResult, Server, ServerTransport,
     },
-    storage::{self, kv::SnapContext, txn::flow_controller::FlowController, Engine},
+    storage::{
+        self,
+        kv::SnapContext,
+        txn::flow_controller::{EngineFlowController, FlowController},
+        Engine,
+    },
 };
 use tikv_util::{
     box_err,
     config::VersionTrack,
     quota_limiter::QuotaLimiter,
+    sys::thread::ThreadBuildWrapper,
     thd_name,
     time::ThreadReadId,
     worker::{Builder as WorkerBuilder, LazyWorker},
@@ -281,15 +287,23 @@ impl ServerCluster {
             }
         }
 
-        let local_reader = LocalReader::new(engines.kv.clone(), store_meta.clone(), router.clone());
-        let raft_router = ServerRaftStoreRouter::new(router.clone(), local_reader);
-        let sim_router = SimulateTransport::new(raft_router.clone());
-
-        let raft_engine = RaftKv::new(sim_router.clone(), engines.kv.clone());
+        let local_reader = LocalReader::new(
+            engines.kv.clone(),
+            StoreMetaDelegate::new(store_meta.clone(), engines.kv.clone()),
+            router.clone(),
+        );
 
         // Create coprocessor.
         let mut coprocessor_host = CoprocessorHost::new(router.clone(), cfg.coprocessor.clone());
         let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
+
+        let raft_router = ServerRaftStoreRouter::new(router.clone(), local_reader);
+        let sim_router = SimulateTransport::new(raft_router.clone());
+        let raft_engine = RaftKv::new(
+            sim_router.clone(),
+            engines.kv.clone(),
+            region_info_accessor.region_leaders(),
+        );
 
         if let Some(hooks) = self.coprocessor_hooks.get(&node_id) {
             for hook in hooks {
@@ -306,7 +320,11 @@ impl ServerCluster {
             raft_engine.clone(),
         ));
 
-        let mut engine = RaftKv::new(sim_router.clone(), engines.kv.clone());
+        let mut engine = RaftKv::new(
+            sim_router.clone(),
+            engines.kv.clone(),
+            region_info_accessor.region_leaders(),
+        );
         if let Some(scheduler) = self.txn_extra_schedulers.remove(&node_id) {
             engine.set_txn_extra_scheduler(scheduler);
         }
@@ -322,8 +340,9 @@ impl ServerCluster {
             tx,
             cfg.gc.clone(),
             Default::default(),
+            Arc::new(region_info_accessor.clone()),
         );
-        gc_worker.start().unwrap();
+        gc_worker.start(node_id).unwrap();
         gc_worker
             .start_observe_lock_apply(&mut coprocessor_host, concurrency_manager.clone())
             .unwrap();
@@ -357,13 +376,16 @@ impl ServerCluster {
                 block_on(causal_ts::BatchTsoProvider::new_opt(
                     self.pd_client.clone(),
                     cfg.causal_ts.renew_interval.0,
+                    cfg.causal_ts.available_interval.0,
                     cfg.causal_ts.renew_batch_min_size,
+                    cfg.causal_ts.renew_batch_max_size,
                 ))
                 .unwrap(),
             );
             self.causal_ts_providers
                 .insert(node_id, causal_ts_provider.clone());
-            let causal_ob = causal_ts::CausalObserver::new(causal_ts_provider);
+            let causal_ob =
+                causal_ts::CausalObserver::new(causal_ts_provider, DummyRawTsTracker::default());
             causal_ob.register_to(&mut coprocessor_host);
         }
 
@@ -409,7 +431,11 @@ impl ServerCluster {
             cfg.quota.foreground_cpu_time,
             cfg.quota.foreground_write_bandwidth,
             cfg.quota.foreground_read_bandwidth,
+            cfg.quota.background_cpu_time,
+            cfg.quota.background_write_bandwidth,
+            cfg.quota.background_read_bandwidth,
             cfg.quota.max_delay_duration,
+            cfg.quota.enable_auto_tune,
         ));
         let store = create_raft_storage::<_, _, _, F, _>(
             engine,
@@ -418,7 +444,7 @@ impl ServerCluster {
             lock_mgr.clone(),
             concurrency_manager.clone(),
             lock_mgr.get_storage_dynamic_configs(),
-            Arc::new(FlowController::empty()),
+            Arc::new(FlowController::Singleton(EngineFlowController::empty())),
             pd_sender,
             res_tag_factory.clone(),
             quota_limiter.clone(),
@@ -439,6 +465,7 @@ impl ServerCluster {
             .max_total_size(cfg.server.snap_max_total_size.0)
             .encryption_key_manager(key_manager)
             .max_per_file_size(cfg.raft_store.max_snapshot_file_raw_size.0)
+            .enable_multi_snapshot_files(true)
             .build(tmp_str);
         self.snap_mgrs.insert(node_id, snap_mgr.clone());
         let server_cfg = Arc::new(VersionTrack::new(cfg.server.clone()));
@@ -461,6 +488,8 @@ impl ServerCluster {
             TokioBuilder::new_multi_thread()
                 .thread_name(thd_name!("debugger"))
                 .worker_threads(1)
+                .after_start_wrapper(|| {})
+                .before_stop_wrapper(|| {})
                 .build()
                 .unwrap(),
         );
@@ -469,7 +498,11 @@ impl ServerCluster {
         // Create node.
         let mut raft_store = cfg.raft_store.clone();
         raft_store
-            .validate(cfg.coprocessor.region_split_size)
+            .validate(
+                cfg.coprocessor.region_split_size,
+                cfg.coprocessor.enable_region_bucket,
+                cfg.coprocessor.region_bucket_size,
+            )
             .unwrap();
         let health_service = HealthService::default();
         let mut node = Node::new(
@@ -531,11 +564,13 @@ impl ServerCluster {
         cfg.server.addr = format!("{}", addr);
         let trans = server.transport();
         let simulate_trans = SimulateTransport::new(trans);
+        let max_grpc_thread_count = cfg.server.grpc_concurrency;
         let server_cfg = Arc::new(VersionTrack::new(cfg.server.clone()));
 
         // Register the role change observer of the lock manager.
         lock_mgr.register_detector_role_change_observer(&mut coprocessor_host);
 
+        let max_unified_read_pool_thread_count = cfg.readpool.unified.max_thread_count;
         let pessimistic_txn_cfg = cfg.tikv.pessimistic_txn;
 
         let split_check_runner =
@@ -543,7 +578,12 @@ impl ServerCluster {
         let split_check_scheduler = bg_worker.start("split-check", split_check_runner);
         let split_config_manager =
             SplitConfigManager::new(Arc::new(VersionTrack::new(cfg.tikv.split)));
-        let auto_split_controller = AutoSplitController::new(split_config_manager);
+        let auto_split_controller = AutoSplitController::new(
+            split_config_manager,
+            max_grpc_thread_count,
+            max_unified_read_pool_thread_count,
+            None,
+        );
         node.start(
             engines,
             simulate_trans.clone(),

--- a/new-mock-engine-store/src/server.rs
+++ b/new-mock-engine-store/src/server.rs
@@ -1,0 +1,887 @@
+// Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    path::Path,
+    sync::{Arc, Mutex, RwLock},
+    thread,
+    time::Duration,
+    usize,
+};
+
+use api_version::{dispatch_api_version, KvFormat};
+use causal_ts::CausalTsProvider;
+use collections::{HashMap, HashSet};
+use concurrency_manager::ConcurrencyManager;
+use encryption_export::DataKeyManager;
+use engine_rocks::RocksSnapshot;
+use engine_traits::{Engines, MiscExt};
+use futures::executor::block_on;
+use grpcio::{ChannelBuilder, EnvBuilder, Environment, Error as GrpcError, Service};
+use grpcio_health::HealthService;
+use kvproto::{
+    deadlock::create_deadlock,
+    debugpb::{create_debug, DebugClient},
+    import_sstpb::create_import_sst,
+    kvrpcpb::{ApiVersion, Context},
+    metapb,
+    raft_cmdpb::*,
+    raft_serverpb,
+    tikvpb::TikvClient,
+};
+use pd_client::PdClient;
+use raftstore::{
+    coprocessor::{CoprocessorHost, RegionInfoAccessor},
+    errors::Error as RaftError,
+    router::{LocalReadRouter, RaftStoreBlackHole, RaftStoreRouter, ServerRaftStoreRouter},
+    store::{
+        fsm::{store::StoreMeta, ApplyRouter, RaftBatchSystem, RaftRouter},
+        msg::RaftCmdExtraOpts,
+        AutoSplitController, Callback, CheckLeaderRunner, LocalReader, RegionSnapshot, SnapManager,
+        SnapManagerBuilder, SplitCheckRunner, SplitConfigManager,
+    },
+    Result,
+};
+use resource_metering::{CollectorRegHandle, ResourceTagFactory};
+use security::SecurityManager;
+use tempfile::TempDir;
+use tikv::{
+    config::ConfigController,
+    coprocessor, coprocessor_v2,
+    import::{ImportSstService, SstImporter},
+    read_pool::ReadPool,
+    server::{
+        create_raft_storage,
+        gc_worker::GcWorker,
+        load_statistics::ThreadLoadPool,
+        lock_manager::LockManager,
+        raftkv::ReplicaReadLockChecker,
+        resolve::{self, StoreAddrResolver},
+        service::DebugService,
+        ConnectionBuilder, Error, Node, PdStoreAddrResolver, RaftClient, RaftKv,
+        Result as ServerResult, Server, ServerTransport,
+    },
+    storage::{self, kv::SnapContext, txn::flow_controller::FlowController, Engine},
+};
+use tikv_util::{
+    config::VersionTrack,
+    quota_limiter::QuotaLimiter,
+    time::ThreadReadId,
+    worker::{Builder as WorkerBuilder, LazyWorker},
+    HandyRwLock, box_err, thd_name,
+};
+use tokio::runtime::Builder as TokioBuilder;
+use txn_types::TxnExtraScheduler;
+
+use super::*;
+use crate::config::Config;
+
+use transport_simulate::SimulateTransport;
+
+type SimulateStoreTransport = SimulateTransport<ServerRaftStoreRouter<TiFlashEngine, engine_rocks::RocksEngine>>;
+type SimulateServerTransport =
+    SimulateTransport<ServerTransport<SimulateStoreTransport, PdStoreAddrResolver, TiFlashEngine>>;
+
+pub type SimulateEngine = RaftKv<TiFlashEngine, SimulateStoreTransport>;
+
+#[derive(Default, Clone)]
+pub struct AddressMap {
+    addrs: Arc<Mutex<HashMap<u64, String>>>,
+}
+
+impl AddressMap {
+    pub fn get(&self, store_id: u64) -> Option<String> {
+        let addrs = self.addrs.lock().unwrap();
+        addrs.get(&store_id).cloned()
+    }
+
+    pub fn insert(&mut self, store_id: u64, addr: String) {
+        self.addrs.lock().unwrap().insert(store_id, addr);
+    }
+}
+
+impl StoreAddrResolver for AddressMap {
+    fn resolve(
+        &self,
+        store_id: u64,
+        cb: Box<dyn FnOnce(ServerResult<String>) + Send>,
+    ) -> ServerResult<()> {
+        let addr = self.get(store_id);
+        match addr {
+            Some(addr) => cb(Ok(addr)),
+            None => cb(Err(box_err!(
+                "unable to find address for store {}",
+                store_id
+            ))),
+        }
+        Ok(())
+    }
+}
+
+struct ServerMeta {
+    node: Node<TestPdClient, TiFlashEngine, engine_rocks::RocksEngine>,
+    server: Server<SimulateStoreTransport, PdStoreAddrResolver, SimulateEngine>,
+    sim_router: SimulateStoreTransport,
+    sim_trans: SimulateServerTransport,
+    raw_router: RaftRouter<TiFlashEngine, engine_rocks::RocksEngine>,
+    raw_apply_router: ApplyRouter<TiFlashEngine>,
+    gc_worker: GcWorker<RaftKv<TiFlashEngine, SimulateStoreTransport>, SimulateStoreTransport>,
+    rts_worker: Option<LazyWorker<resolved_ts::Task<RocksSnapshot>>>,
+    rsmeter_cleanup: Box<dyn FnOnce()>,
+}
+
+type PendingServices = Vec<Box<dyn Fn() -> Service>>;
+type CopHooks = Vec<Box<dyn Fn(&mut CoprocessorHost<TiFlashEngine>)>>;
+
+pub struct ServerCluster {
+    metas: HashMap<u64, ServerMeta>,
+    addrs: AddressMap,
+    pub storages: HashMap<u64, SimulateEngine>,
+    pub region_info_accessors: HashMap<u64, RegionInfoAccessor>,
+    pub importers: HashMap<u64, Arc<SstImporter>>,
+    pub pending_services: HashMap<u64, PendingServices>,
+    pub coprocessor_hooks: HashMap<u64, CopHooks>,
+    pub health_services: HashMap<u64, HealthService>,
+    pub security_mgr: Arc<SecurityManager>,
+    pub txn_extra_schedulers: HashMap<u64, Arc<dyn TxnExtraScheduler>>,
+    snap_paths: HashMap<u64, TempDir>,
+    snap_mgrs: HashMap<u64, SnapManager>,
+    pd_client: Arc<TestPdClient>,
+    raft_client: RaftClient<AddressMap, RaftStoreBlackHole, TiFlashEngine>,
+    concurrency_managers: HashMap<u64, ConcurrencyManager>,
+    env: Arc<Environment>,
+    pub causal_ts_providers: HashMap<u64, Arc<dyn CausalTsProvider>>,
+}
+
+impl ServerCluster {
+    pub fn new(pd_client: Arc<TestPdClient>) -> ServerCluster {
+        let env = Arc::new(
+            EnvBuilder::new()
+                .cq_count(2)
+                .name_prefix(thd_name!("server-cluster"))
+                .build(),
+        );
+        let security_mgr = Arc::new(SecurityManager::new(&Default::default()).unwrap());
+        let map = AddressMap::default();
+        // We don't actually need to handle snapshot message, just create a dead worker to make it compile.
+        let worker = LazyWorker::new("snap-worker");
+        let conn_builder = ConnectionBuilder::new(
+            env.clone(),
+            Arc::default(),
+            security_mgr.clone(),
+            map.clone(),
+            RaftStoreBlackHole,
+            worker.scheduler(),
+            Arc::new(ThreadLoadPool::with_threshold(usize::MAX)),
+        );
+        let raft_client = RaftClient::new(conn_builder);
+        ServerCluster {
+            metas: HashMap::default(),
+            addrs: map,
+            pd_client,
+            security_mgr,
+            storages: HashMap::default(),
+            region_info_accessors: HashMap::default(),
+            importers: HashMap::default(),
+            snap_paths: HashMap::default(),
+            snap_mgrs: HashMap::default(),
+            pending_services: HashMap::default(),
+            coprocessor_hooks: HashMap::default(),
+            health_services: HashMap::default(),
+            raft_client,
+            concurrency_managers: HashMap::default(),
+            env,
+            txn_extra_schedulers: HashMap::default(),
+            causal_ts_providers: HashMap::default(),
+        }
+    }
+
+    pub fn get_addr(&self, node_id: u64) -> String {
+        self.addrs.get(node_id).unwrap()
+    }
+
+    pub fn get_apply_router(&self, node_id: u64) -> ApplyRouter<TiFlashEngine> {
+        self.metas.get(&node_id).unwrap().raw_apply_router.clone()
+    }
+
+    pub fn get_server_router(&self, node_id: u64) -> SimulateStoreTransport {
+        self.metas.get(&node_id).unwrap().sim_router.clone()
+    }
+
+    /// To trigger GC manually.
+    pub fn get_gc_worker(
+        &self,
+        node_id: u64,
+    ) -> &GcWorker<RaftKv<TiFlashEngine, SimulateStoreTransport>, SimulateStoreTransport> {
+        &self.metas.get(&node_id).unwrap().gc_worker
+    }
+
+    pub fn get_concurrency_manager(&self, node_id: u64) -> ConcurrencyManager {
+        self.concurrency_managers.get(&node_id).unwrap().clone()
+    }
+
+    pub fn get_causal_ts_provider(&self, node_id: u64) -> Option<Arc<dyn CausalTsProvider>> {
+        self.causal_ts_providers.get(&node_id).cloned()
+    }
+
+    fn init_resource_metering(
+        &self,
+        cfg: &resource_metering::Config,
+    ) -> (ResourceTagFactory, CollectorRegHandle, Box<dyn FnOnce()>) {
+        let (_, collector_reg_handle, resource_tag_factory, recorder_worker) =
+            resource_metering::init_recorder(cfg.precision.as_millis());
+        let (_, data_sink_reg_handle, reporter_worker) =
+            resource_metering::init_reporter(cfg.clone(), collector_reg_handle.clone());
+        let (_, single_target_worker) = resource_metering::init_single_target(
+            cfg.receiver_address.clone(),
+            Arc::new(Environment::new(2)),
+            data_sink_reg_handle,
+        );
+
+        (
+            resource_tag_factory,
+            collector_reg_handle,
+            Box::new(move || {
+                single_target_worker.stop_worker();
+                reporter_worker.stop_worker();
+                recorder_worker.stop_worker();
+            }),
+        )
+    }
+
+    fn run_node_impl<F: KvFormat>(
+        &mut self,
+        node_id: u64,
+        mut cfg: Config,
+        engines: Engines<TiFlashEngine, engine_rocks::RocksEngine>,
+        store_meta: Arc<Mutex<StoreMeta>>,
+        key_manager: Option<Arc<DataKeyManager>>,
+        router: RaftRouter<TiFlashEngine, engine_rocks::RocksEngine>,
+        system: RaftBatchSystem<TiFlashEngine, engine_rocks::RocksEngine>,
+    ) -> ServerResult<u64> {
+        let (tmp_str, tmp) = if node_id == 0 || !self.snap_paths.contains_key(&node_id) {
+            let p = test_util::temp_dir("test_cluster", cfg.prefer_mem);
+            (p.path().to_str().unwrap().to_owned(), Some(p))
+        } else {
+            let p = self.snap_paths[&node_id].path().to_str().unwrap();
+            (p.to_owned(), None)
+        };
+
+        let bg_worker = WorkerBuilder::new("background").thread_count(2).create();
+
+        if cfg.server.addr == "127.0.0.1:0" {
+            // Now we cache the store address, so here we should re-use last
+            // listening address for the same store.
+            if let Some(addr) = self.addrs.get(node_id) {
+                cfg.server.addr = addr;
+            } else {
+                cfg.server.addr = format!("127.0.0.1:{}", test_util::alloc_port());
+            }
+        }
+
+        let local_reader = LocalReader::new(engines.kv.clone(), store_meta.clone(), router.clone());
+        let raft_router = ServerRaftStoreRouter::new(router.clone(), local_reader);
+        let sim_router = SimulateTransport::new(raft_router.clone());
+
+        let raft_engine = RaftKv::new(sim_router.clone(), engines.kv.clone());
+
+        // Create coprocessor.
+        let mut coprocessor_host = CoprocessorHost::new(router.clone(), cfg.coprocessor.clone());
+        let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
+
+        if let Some(hooks) = self.coprocessor_hooks.get(&node_id) {
+            for hook in hooks {
+                hook(&mut coprocessor_host);
+            }
+        }
+
+        // Create storage.
+        let pd_worker = LazyWorker::new("test-pd-worker");
+        let pd_sender = pd_worker.scheduler();
+        let storage_read_pool = ReadPool::from(storage::build_read_pool(
+            &tikv::config::StorageReadPoolConfig::default_for_test(),
+            pd_sender.clone(),
+            raft_engine.clone(),
+        ));
+
+        let mut engine = RaftKv::new(sim_router.clone(), engines.kv.clone());
+        if let Some(scheduler) = self.txn_extra_schedulers.remove(&node_id) {
+            engine.set_txn_extra_scheduler(scheduler);
+        }
+
+        let latest_ts =
+            block_on(self.pd_client.get_tso()).expect("failed to get timestamp from PD");
+        let concurrency_manager = ConcurrencyManager::new(latest_ts);
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut gc_worker = GcWorker::new(
+            engine.clone(),
+            sim_router.clone(),
+            tx,
+            cfg.gc.clone(),
+            Default::default(),
+        );
+        gc_worker.start().unwrap();
+        gc_worker
+            .start_observe_lock_apply(&mut coprocessor_host, concurrency_manager.clone())
+            .unwrap();
+
+        let rts_worker = if cfg.resolved_ts.enable {
+            // Resolved ts worker
+            let mut rts_worker = LazyWorker::new("resolved-ts");
+            let rts_ob = resolved_ts::Observer::new(rts_worker.scheduler());
+            rts_ob.register_to(&mut coprocessor_host);
+            // Resolved ts endpoint
+            let rts_endpoint = resolved_ts::Endpoint::new(
+                &cfg.resolved_ts,
+                rts_worker.scheduler(),
+                raft_router.clone(),
+                store_meta.clone(),
+                self.pd_client.clone(),
+                concurrency_manager.clone(),
+                self.env.clone(),
+                self.security_mgr.clone(),
+                resolved_ts::DummySinker::new(),
+            );
+            // Start the worker
+            rts_worker.start(rts_endpoint);
+            Some(rts_worker)
+        } else {
+            None
+        };
+
+        if ApiVersion::V2 == F::TAG {
+            let causal_ts_provider = Arc::new(
+                block_on(causal_ts::BatchTsoProvider::new_opt(
+                    self.pd_client.clone(),
+                    cfg.causal_ts.renew_interval.0,
+                    cfg.causal_ts.renew_batch_min_size,
+                ))
+                .unwrap(),
+            );
+            self.causal_ts_providers
+                .insert(node_id, causal_ts_provider.clone());
+            let causal_ob = causal_ts::CausalObserver::new(causal_ts_provider);
+            causal_ob.register_to(&mut coprocessor_host);
+        }
+
+        // Start resource metering.
+        let (res_tag_factory, collector_reg_handle, rsmeter_cleanup) =
+            self.init_resource_metering(&cfg.resource_metering);
+
+        // Create import service.
+        let importer = {
+            let dir = Path::new(engines.kv.path()).join("import-sst");
+            Arc::new(
+                SstImporter::new(
+                    &cfg.import,
+                    dir,
+                    key_manager.clone(),
+                    cfg.storage.api_version(),
+                )
+                .unwrap(),
+            )
+        };
+        let import_service = ImportSstService::new(
+            cfg.import.clone(),
+            cfg.raft_store.raft_entry_max_size,
+            sim_router.clone(),
+            engines.kv.clone(),
+            Arc::clone(&importer),
+        );
+
+        let tiflash_ob = engine_store_ffi::observer::TiFlashObserver::new(
+            node_id,
+            engines.kv.clone(),
+            importer.clone(),
+            2,
+        );
+        tiflash_ob.register_to(&mut coprocessor_host);
+
+        let check_leader_runner =
+            CheckLeaderRunner::new(store_meta.clone(), coprocessor_host.clone());
+        let check_leader_scheduler = bg_worker.start("check-leader", check_leader_runner);
+
+        let mut lock_mgr = LockManager::new(&cfg.pessimistic_txn);
+        let quota_limiter = Arc::new(QuotaLimiter::new(
+            cfg.quota.foreground_cpu_time,
+            cfg.quota.foreground_write_bandwidth,
+            cfg.quota.foreground_read_bandwidth,
+            cfg.quota.max_delay_duration,
+        ));
+        let store = create_raft_storage::<_, _, _, F, _>(
+            engine,
+            &cfg.storage,
+            storage_read_pool.handle(),
+            lock_mgr.clone(),
+            concurrency_manager.clone(),
+            lock_mgr.get_storage_dynamic_configs(),
+            Arc::new(FlowController::empty()),
+            pd_sender,
+            res_tag_factory.clone(),
+            quota_limiter.clone(),
+            self.pd_client.feature_gate().clone(),
+        )?;
+        self.storages.insert(node_id, raft_engine);
+
+        ReplicaReadLockChecker::new(concurrency_manager.clone()).register(&mut coprocessor_host);
+
+        // Create deadlock service.
+        let deadlock_service = lock_mgr.deadlock_service();
+
+        // Create pd client, snapshot manager, server.
+        let (resolver, state) =
+            resolve::new_resolver(Arc::clone(&self.pd_client), &bg_worker, router.clone());
+        let snap_mgr = SnapManagerBuilder::default()
+            .max_write_bytes_per_sec(cfg.server.snap_max_write_bytes_per_sec.0 as i64)
+            .max_total_size(cfg.server.snap_max_total_size.0)
+            .encryption_key_manager(key_manager)
+            .max_per_file_size(cfg.raft_store.max_snapshot_file_raw_size.0)
+            .build(tmp_str);
+        self.snap_mgrs.insert(node_id, snap_mgr.clone());
+        let server_cfg = Arc::new(VersionTrack::new(cfg.server.clone()));
+        let security_mgr = Arc::new(SecurityManager::new(&cfg.security).unwrap());
+        let cop_read_pool = ReadPool::from(coprocessor::readpool_impl::build_read_pool_for_test(
+            &tikv::config::CoprReadPoolConfig::default_for_test(),
+            store.get_engine(),
+        ));
+        let copr = coprocessor::Endpoint::new(
+            &server_cfg.value().clone(),
+            cop_read_pool.handle(),
+            concurrency_manager.clone(),
+            res_tag_factory,
+            quota_limiter,
+        );
+        let copr_v2 = coprocessor_v2::Endpoint::new(&cfg.coprocessor_v2);
+        let mut server = None;
+        // Create Debug service.
+        let debug_thread_pool = Arc::new(
+            TokioBuilder::new_multi_thread()
+                .thread_name(thd_name!("debugger"))
+                .worker_threads(1)
+                .build()
+                .unwrap(),
+        );
+
+        let apply_router = system.apply_router();
+        // Create node.
+        let mut raft_store = cfg.raft_store.clone();
+        raft_store
+            .validate(cfg.coprocessor.region_split_size)
+            .unwrap();
+        let health_service = HealthService::default();
+        let mut node = Node::new(
+            system,
+            &server_cfg.value().clone(),
+            Arc::new(VersionTrack::new(raft_store)),
+            cfg.storage.api_version(),
+            Arc::clone(&self.pd_client),
+            state,
+            bg_worker.clone(),
+            Some(health_service.clone()),
+            None,
+        );
+        node.try_bootstrap_store(engines.clone())?;
+        let node_id = node.id();
+
+        for _ in 0..100 {
+            let mut svr = Server::new(
+                node_id,
+                &server_cfg,
+                &security_mgr,
+                store.clone(),
+                copr.clone(),
+                copr_v2.clone(),
+                sim_router.clone(),
+                resolver.clone(),
+                snap_mgr.clone(),
+                gc_worker.clone(),
+                check_leader_scheduler.clone(),
+                self.env.clone(),
+                None,
+                debug_thread_pool.clone(),
+                health_service.clone(),
+            )
+            .unwrap();
+            svr.register_service(create_import_sst(import_service.clone()));
+            svr.register_service(create_deadlock(deadlock_service.clone()));
+            if let Some(svcs) = self.pending_services.get(&node_id) {
+                for fact in svcs {
+                    svr.register_service(fact());
+                }
+            }
+            match svr.build_and_bind() {
+                Ok(_) => {
+                    server = Some(svr);
+                    break;
+                }
+                Err(Error::Grpc(GrpcError::BindFail(ref addr, ref port))) => {
+                    // Servers may meet the error, when we restart them.
+                    debug!("fail to create a server: bind fail {:?}", (addr, port));
+                    thread::sleep(Duration::from_millis(100));
+                    continue;
+                }
+                Err(ref e) => panic!("fail to create a server: {:?}", e),
+            }
+        }
+        let mut server = server.unwrap();
+        let addr = server.listening_addr();
+        cfg.server.addr = format!("{}", addr);
+        let trans = server.transport();
+        let simulate_trans = SimulateTransport::new(trans);
+        let server_cfg = Arc::new(VersionTrack::new(cfg.server.clone()));
+
+        // Register the role change observer of the lock manager.
+        lock_mgr.register_detector_role_change_observer(&mut coprocessor_host);
+
+        let pessimistic_txn_cfg = cfg.tikv.pessimistic_txn;
+
+        let split_check_runner =
+            SplitCheckRunner::new(engines.kv.clone(), router.clone(), coprocessor_host.clone());
+        let split_check_scheduler = bg_worker.start("split-check", split_check_runner);
+        let split_config_manager =
+            SplitConfigManager::new(Arc::new(VersionTrack::new(cfg.tikv.split)));
+        let auto_split_controller = AutoSplitController::new(split_config_manager);
+        node.start(
+            engines,
+            simulate_trans.clone(),
+            snap_mgr,
+            pd_worker,
+            store_meta,
+            coprocessor_host,
+            importer.clone(),
+            split_check_scheduler,
+            auto_split_controller,
+            concurrency_manager.clone(),
+            collector_reg_handle,
+        )?;
+        assert!(node_id == 0 || node_id == node.id());
+        let node_id = node.id();
+        if let Some(tmp) = tmp {
+            self.snap_paths.insert(node_id, tmp);
+        }
+        self.region_info_accessors
+            .insert(node_id, region_info_accessor);
+        self.importers.insert(node_id, importer);
+        self.health_services.insert(node_id, health_service);
+
+        lock_mgr
+            .start(
+                node.id(),
+                Arc::clone(&self.pd_client),
+                resolver,
+                Arc::clone(&security_mgr),
+                &pessimistic_txn_cfg,
+            )
+            .unwrap();
+
+        server.start(server_cfg, security_mgr).unwrap();
+
+        self.metas.insert(
+            node_id,
+            ServerMeta {
+                raw_router: router,
+                raw_apply_router: apply_router,
+                node,
+                server,
+                sim_router,
+                sim_trans: simulate_trans,
+                gc_worker,
+                rts_worker,
+                rsmeter_cleanup,
+            },
+        );
+        self.addrs.insert(node_id, format!("{}", addr));
+        self.concurrency_managers
+            .insert(node_id, concurrency_manager);
+
+        Ok(node_id)
+    }
+}
+
+impl Simulator<TiFlashEngine> for ServerCluster {
+    fn run_node(
+        &mut self,
+        node_id: u64,
+        cfg: Config,
+        engines: Engines<TiFlashEngine, engine_rocks::RocksEngine>,
+        store_meta: Arc<Mutex<StoreMeta>>,
+        key_manager: Option<Arc<DataKeyManager>>,
+        router: RaftRouter<TiFlashEngine, engine_rocks::RocksEngine>,
+        system: RaftBatchSystem<TiFlashEngine, engine_rocks::RocksEngine>,
+    ) -> ServerResult<u64> {
+        dispatch_api_version!(
+            cfg.storage.api_version(),
+            self.run_node_impl::<API>(
+                node_id,
+                cfg,
+                engines,
+                store_meta,
+                key_manager,
+                router,
+                system,
+            )
+        )
+    }
+
+    fn get_snap_dir(&self, node_id: u64) -> String {
+        self.snap_paths[&node_id]
+            .path()
+            .to_str()
+            .unwrap()
+            .to_owned()
+    }
+
+    fn get_snap_mgr(&self, node_id: u64) -> &SnapManager {
+        self.snap_mgrs.get(&node_id).unwrap()
+    }
+
+    fn stop_node(&mut self, node_id: u64) {
+        if let Some(mut meta) = self.metas.remove(&node_id) {
+            meta.server.stop().unwrap();
+            meta.node.stop();
+            // resolved ts worker started, let's stop it
+            if let Some(worker) = meta.rts_worker {
+                worker.stop_worker();
+            }
+            (meta.rsmeter_cleanup)();
+        }
+    }
+
+    fn get_node_ids(&self) -> HashSet<u64> {
+        self.metas.keys().cloned().collect()
+    }
+
+    fn async_command_on_node_with_opts(
+        &self,
+        node_id: u64,
+        request: RaftCmdRequest,
+        cb: Callback<RocksSnapshot>,
+        opts: RaftCmdExtraOpts,
+    ) -> Result<()> {
+        let router = match self.metas.get(&node_id) {
+            None => return Err(box_err!("missing sender for store {}", node_id)),
+            Some(meta) => meta.sim_router.clone(),
+        };
+        router.send_command(request, cb, opts)
+    }
+
+    fn async_read(
+        &self,
+        node_id: u64,
+        batch_id: Option<ThreadReadId>,
+        request: RaftCmdRequest,
+        cb: Callback<RocksSnapshot>,
+    ) {
+        match self.metas.get(&node_id) {
+            None => {
+                let e: RaftError = box_err!("missing sender for store {}", node_id);
+                let mut resp = RaftCmdResponse::default();
+                resp.mut_header().set_error(e.into());
+                cb.invoke_with_response(resp);
+            }
+            Some(meta) => {
+                meta.sim_router.read(batch_id, request, cb).unwrap();
+            }
+        };
+    }
+
+    fn send_raft_msg(&mut self, raft_msg: raft_serverpb::RaftMessage) -> Result<()> {
+        self.raft_client.send(raft_msg).unwrap();
+        self.raft_client.flush();
+        Ok(())
+    }
+
+    fn clear_send_filters(&mut self, node_id: u64) {
+        self.metas
+            .get_mut(&node_id)
+            .unwrap()
+            .sim_trans
+            .clear_filters();
+    }
+
+    fn clear_recv_filters(&mut self, node_id: u64) {
+        self.metas
+            .get_mut(&node_id)
+            .unwrap()
+            .sim_router
+            .clear_filters();
+    }
+
+    fn get_router(&self, node_id: u64) -> Option<RaftRouter<TiFlashEngine, engine_rocks::RocksEngine>> {
+        self.metas.get(&node_id).map(|m| m.raw_router.clone())
+    }
+
+    fn async_command_on_node(
+        &self,
+        node_id: u64,
+        request: RaftCmdRequest,
+        cb: Callback<engine_rocks::RocksSnapshot>,
+    ) -> Result<()> {
+        self.async_command_on_node_with_opts(node_id, request, cb, Default::default())
+    }
+
+    fn call_command(&self, request: RaftCmdRequest, timeout: Duration) -> Result<RaftCmdResponse> {
+        let node_id = request.get_header().get_peer().get_store_id();
+        self.call_command_on_node(node_id, request, timeout)
+    }
+
+    fn read(
+        &self,
+        batch_id: Option<ThreadReadId>,
+        request: RaftCmdRequest,
+        timeout: Duration,
+    ) -> Result<RaftCmdResponse> {
+        let node_id = request.get_header().get_peer().get_store_id();
+        let (cb, rx) = test_raftstore::make_cb(&request);
+        self.async_read(node_id, batch_id, request, cb);
+        rx.recv_timeout(timeout)
+            .map_err(|_| RaftError::Timeout(format!("request timeout for {:?}", timeout)))
+    }
+
+    fn call_command_on_node(
+        &self,
+        node_id: u64,
+        request: RaftCmdRequest,
+        timeout: Duration,
+    ) -> Result<RaftCmdResponse> {
+        let (cb, rx) = test_raftstore::make_cb(&request);
+
+        match self.async_command_on_node(node_id, request, cb) {
+            Ok(()) => {}
+            Err(e) => {
+                let mut resp = RaftCmdResponse::default();
+                resp.mut_header().set_error(e.into());
+                return Ok(resp);
+            }
+        }
+        rx.recv_timeout(timeout)
+            .map_err(|e| RaftError::Timeout(format!("request timeout for {:?}: {:?}", timeout, e)))
+    }
+
+    fn add_send_filter(&mut self, node_id: u64, filter: Box<dyn test_raftstore::Filter>) {
+        todo!()
+    }
+
+    fn add_recv_filter(&mut self, node_id: u64, filter: Box<dyn test_raftstore::Filter>) {
+        todo!()
+    }
+}
+
+impl Cluster<ServerCluster> {
+    pub fn must_get_snapshot_of_region(&mut self, region_id: u64) -> RegionSnapshot<RocksSnapshot> {
+        let mut try_snapshot = || -> Option<RegionSnapshot<RocksSnapshot>> {
+            let leader = self.leader_of_region(region_id)?;
+            let store_id = leader.store_id;
+            let epoch = self.get_region_epoch(region_id);
+            let mut ctx = Context::default();
+            ctx.set_region_id(region_id);
+            ctx.set_peer(leader);
+            ctx.set_region_epoch(epoch);
+
+            let storage = self.sim.rl().storages.get(&store_id).unwrap().clone();
+            let snap_ctx = SnapContext {
+                pb_ctx: &ctx,
+                ..Default::default()
+            };
+            storage.snapshot(snap_ctx).ok()
+        };
+        for _ in 0..10 {
+            if let Some(snapshot) = try_snapshot() {
+                return snapshot;
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+        panic!("failed to get snapshot of region {}", region_id);
+    }
+}
+
+pub fn new_server_cluster(id: u64, count: usize) -> Cluster<ServerCluster> {
+    let pd_client = Arc::new(TestPdClient::new(id, false));
+    let sim = Arc::new(RwLock::new(ServerCluster::new(Arc::clone(&pd_client))));
+    Cluster::new(id, count, sim, pd_client, ProxyConfig::default())
+}
+
+pub fn new_server_cluster_with_api_ver(
+    id: u64,
+    count: usize,
+    api_ver: ApiVersion,
+) -> Cluster<ServerCluster> {
+    let pd_client = Arc::new(TestPdClient::new(id, false));
+    let sim = Arc::new(RwLock::new(ServerCluster::new(Arc::clone(&pd_client))));
+    Cluster::new(id, count, sim, pd_client, ProxyConfig::default())
+}
+
+pub fn new_incompatible_server_cluster(id: u64, count: usize) -> Cluster<ServerCluster> {
+    let pd_client = Arc::new(TestPdClient::new(id, true));
+    let sim = Arc::new(RwLock::new(ServerCluster::new(Arc::clone(&pd_client))));
+    Cluster::new(id, count, sim, pd_client, ProxyConfig::default())
+}
+
+pub fn must_new_cluster_mul(count: usize) -> (Cluster<ServerCluster>, metapb::Peer, Context) {
+    must_new_and_configure_cluster_mul(count, |_| ())
+}
+
+pub fn must_new_and_configure_cluster(
+    configure: impl FnMut(&mut Cluster<ServerCluster>),
+) -> (Cluster<ServerCluster>, metapb::Peer, Context) {
+    must_new_and_configure_cluster_mul(1, configure)
+}
+
+fn must_new_and_configure_cluster_mul(
+    count: usize,
+    mut configure: impl FnMut(&mut Cluster<ServerCluster>),
+) -> (Cluster<ServerCluster>, metapb::Peer, Context) {
+    let mut cluster = new_server_cluster(0, count);
+    configure(&mut cluster);
+    cluster.run();
+    let region_id = 1;
+    let leader = cluster.leader_of_region(region_id).unwrap();
+    let epoch = cluster.get_region_epoch(region_id);
+    let mut ctx = Context::default();
+    ctx.set_region_id(region_id);
+    ctx.set_peer(leader.clone());
+    ctx.set_region_epoch(epoch);
+
+    (cluster, leader, ctx)
+}
+
+pub fn must_new_cluster_and_kv_client() -> (Cluster<ServerCluster>, TikvClient, Context) {
+    must_new_cluster_and_kv_client_mul(1)
+}
+
+pub fn must_new_cluster_and_kv_client_mul(
+    count: usize,
+) -> (Cluster<ServerCluster>, TikvClient, Context) {
+    let (cluster, leader, ctx) = must_new_cluster_mul(count);
+
+    let env = Arc::new(Environment::new(1));
+    let channel =
+        ChannelBuilder::new(env).connect(&cluster.sim.rl().get_addr(leader.get_store_id()));
+    let client = TikvClient::new(channel);
+
+    (cluster, client, ctx)
+}
+
+pub fn must_new_cluster_and_debug_client() -> (Cluster<ServerCluster>, DebugClient, u64) {
+    let (cluster, leader, _) = must_new_cluster_mul(1);
+
+    let env = Arc::new(Environment::new(1));
+    let channel =
+        ChannelBuilder::new(env).connect(&cluster.sim.rl().get_addr(leader.get_store_id()));
+    let client = DebugClient::new(channel);
+
+    (cluster, client, leader.get_store_id())
+}
+
+pub fn must_new_and_configure_cluster_and_kv_client(
+    configure: impl FnMut(&mut Cluster<ServerCluster>),
+) -> (Cluster<ServerCluster>, TikvClient, Context) {
+    let (cluster, leader, ctx) = must_new_and_configure_cluster(configure);
+
+    let env = Arc::new(Environment::new(1));
+    let channel =
+        ChannelBuilder::new(env).connect(&cluster.sim.rl().get_addr(leader.get_store_id()));
+    let client = TikvClient::new(channel);
+
+    (cluster, client, ctx)
+}

--- a/tests/proxy/mod.rs
+++ b/tests/proxy/mod.rs
@@ -10,3 +10,4 @@ extern crate slog_global;
 mod normal;
 mod proxy;
 mod util;
+mod server_cluster_test;

--- a/tests/proxy/mod.rs
+++ b/tests/proxy/mod.rs
@@ -9,5 +9,5 @@ extern crate slog_global;
 
 mod normal;
 mod proxy;
-mod util;
 mod server_cluster_test;
+mod util;

--- a/tests/proxy/normal.rs
+++ b/tests/proxy/normal.rs
@@ -24,7 +24,6 @@ use new_mock_engine_store::{
         CloneFilterFactory, CollectSnapshotFilter, Direction, RegionPacketFilter,
     },
     Cluster, ProxyConfig, Simulator, TestPdClient,
-    server::ServerCluster
 };
 use pd_client::PdClient;
 use proxy_server::{
@@ -1655,10 +1654,6 @@ mod snapshot {
         }
 
         (cluster, pd_client)
-    }
-
-    fn new_mock_server_cluster(pd_client: Arc<TestPdClient>) -> (ServerCluster) {
-        ServerCluster::new(pd_client)
     }
 
     #[test]

--- a/tests/proxy/normal.rs
+++ b/tests/proxy/normal.rs
@@ -24,6 +24,7 @@ use new_mock_engine_store::{
         CloneFilterFactory, CollectSnapshotFilter, Direction, RegionPacketFilter,
     },
     Cluster, ProxyConfig, Simulator, TestPdClient,
+    server::ServerCluster
 };
 use pd_client::PdClient;
 use proxy_server::{
@@ -1654,6 +1655,10 @@ mod snapshot {
         }
 
         (cluster, pd_client)
+    }
+
+    fn new_mock_server_cluster(pd_client: Arc<TestPdClient>) -> (ServerCluster) {
+        ServerCluster::new(pd_client)
     }
 
     #[test]

--- a/tests/proxy/server_cluster_test.rs
+++ b/tests/proxy/server_cluster_test.rs
@@ -7,9 +7,13 @@ use concurrency_manager::ConcurrencyManager;
 use engine_rocks::RocksSnapshot;
 use grpcio::{ChannelBuilder, ClientUnaryReceiver, Environment};
 use kvproto::{kvrpcpb::*, tikvpb::TikvClient};
+use new_mock_engine_store::{
+    mock_cluster::{get_global_engine_helper_set, sleep_ms},
+    server::{new_server_cluster, ServerCluster},
+    *,
+};
 use online_config::ConfigValue;
 use raftstore::coprocessor::CoprocessorHost;
-use new_mock_engine_store::{*, mock_cluster::{sleep_ms, get_global_engine_helper_set}, server::{new_server_cluster, ServerCluster}};
 use tikv::config::ResolvedTsConfig;
 use tikv_util::{worker::LazyWorker, HandyRwLock};
 use txn_types::TimeStamp;
@@ -20,7 +24,7 @@ pub fn init() {
 }
 
 pub struct TestSuite {
-    pub cluster: Cluster<ServerCluster>,
+    pub cluster: Box<Cluster<ServerCluster>>,
     tikv_cli: HashMap<u64, TikvClient>,
 
     env: Arc<Environment>,
@@ -28,11 +32,11 @@ pub struct TestSuite {
 
 impl TestSuite {
     pub fn new(count: usize) -> Self {
-        let mut cluster = new_server_cluster(1, count);
+        let mut cluster = Box::new(new_server_cluster(1, count));
         Self::with_cluster(count, cluster)
     }
 
-    pub fn with_cluster(count: usize, mut cluster: Cluster<ServerCluster>) -> Self {
+    pub fn with_cluster(count: usize, mut cluster: Box<Cluster<ServerCluster>>) -> Self {
         init();
         let pd_cli = cluster.pd_client.clone();
 
@@ -49,258 +53,22 @@ impl TestSuite {
         self.cluster.shutdown();
     }
 
-    pub fn must_kv_prewrite(
-        &mut self,
-        region_id: u64,
-        muts: Vec<Mutation>,
-        pk: Vec<u8>,
-        ts: TimeStamp,
-    ) {
-        let mut prewrite_req = PrewriteRequest::default();
-        prewrite_req.set_context(self.get_context(region_id));
-        prewrite_req.set_mutations(muts.into_iter().collect());
-        prewrite_req.primary_lock = pk;
-        prewrite_req.start_version = ts.into_inner();
-        prewrite_req.lock_ttl = prewrite_req.start_version + 1;
-        let prewrite_resp = self
-            .get_tikv_client(region_id)
-            .kv_prewrite(&prewrite_req)
-            .unwrap();
-        assert!(
-            !prewrite_resp.has_region_error(),
-            "{:?}",
-            prewrite_resp.get_region_error()
-        );
-        assert!(
-            prewrite_resp.errors.is_empty(),
-            "{:?}",
-            prewrite_resp.get_errors()
-        );
-    }
-
-    pub fn must_kv_commit(
-        &mut self,
-        region_id: u64,
-        keys: Vec<Vec<u8>>,
-        start_ts: TimeStamp,
-        commit_ts: TimeStamp,
-    ) {
-        let mut commit_req = CommitRequest::default();
-        commit_req.set_context(self.get_context(region_id));
-        commit_req.start_version = start_ts.into_inner();
-        commit_req.set_keys(keys.into_iter().collect());
-        commit_req.commit_version = commit_ts.into_inner();
-        let commit_resp = self
-            .get_tikv_client(region_id)
-            .kv_commit(&commit_req)
-            .unwrap();
-        assert!(
-            !commit_resp.has_region_error(),
-            "{:?}",
-            commit_resp.get_region_error()
-        );
-        assert!(!commit_resp.has_error(), "{:?}", commit_resp.get_error());
-    }
-
-    pub fn must_kv_rollback(&mut self, region_id: u64, keys: Vec<Vec<u8>>, start_ts: TimeStamp) {
-        let mut rollback_req = BatchRollbackRequest::default();
-        rollback_req.set_context(self.get_context(region_id));
-        rollback_req.start_version = start_ts.into_inner();
-        rollback_req.set_keys(keys.into_iter().collect());
-        let rollback_resp = self
-            .get_tikv_client(region_id)
-            .kv_batch_rollback(&rollback_req)
-            .unwrap();
-        assert!(
-            !rollback_resp.has_region_error(),
-            "{:?}",
-            rollback_resp.get_region_error()
-        );
-        assert!(
-            !rollback_resp.has_error(),
-            "{:?}",
-            rollback_resp.get_error()
-        );
-    }
-
-    pub fn must_check_txn_status(
-        &mut self,
-        region_id: u64,
-        primary_key: Vec<u8>,
-        lock_ts: TimeStamp,
-        caller_start_ts: TimeStamp,
-        current_ts: TimeStamp,
-        rollback_if_not_exist: bool,
-    ) -> Action {
-        let mut req = CheckTxnStatusRequest::default();
-        req.set_context(self.get_context(region_id));
-        req.set_primary_key(primary_key);
-        req.set_lock_ts(lock_ts.into_inner());
-        req.set_caller_start_ts(caller_start_ts.into_inner());
-        req.set_current_ts(current_ts.into_inner());
-        req.set_rollback_if_not_exist(rollback_if_not_exist);
-        let resp = self
-            .get_tikv_client(region_id)
-            .kv_check_txn_status(&req)
-            .unwrap();
-        assert!(!resp.has_region_error(), "{:?}", resp.get_region_error());
-        assert!(!resp.has_error(), "{:?}", resp.get_error());
-        resp.get_action()
-    }
-
-    pub fn must_acquire_pessimistic_lock(
-        &mut self,
-        region_id: u64,
-        muts: Vec<Mutation>,
-        pk: Vec<u8>,
-        start_ts: TimeStamp,
-        for_update_ts: TimeStamp,
-    ) {
-        let mut lock_req = PessimisticLockRequest::default();
-        lock_req.set_context(self.get_context(region_id));
-        lock_req.set_mutations(muts.into_iter().collect());
-        lock_req.start_version = start_ts.into_inner();
-        lock_req.for_update_ts = for_update_ts.into_inner();
-        lock_req.primary_lock = pk;
-        let lock_resp = self
-            .get_tikv_client(region_id)
-            .kv_pessimistic_lock(&lock_req)
-            .unwrap();
-        assert!(
-            !lock_resp.has_region_error(),
-            "{:?}",
-            lock_resp.get_region_error()
-        );
-        assert!(
-            lock_resp.get_errors().is_empty(),
-            "{:?}",
-            lock_resp.get_errors()
-        );
-    }
-
-    pub fn must_kv_pessimistic_prewrite(
-        &mut self,
-        region_id: u64,
-        muts: Vec<Mutation>,
-        pk: Vec<u8>,
-        ts: TimeStamp,
-        for_update_ts: TimeStamp,
-    ) {
-        let mut prewrite_req = PrewriteRequest::default();
-        prewrite_req.set_context(self.get_context(region_id));
-        prewrite_req.set_mutations(muts.into_iter().collect());
-        prewrite_req.primary_lock = pk;
-        prewrite_req.start_version = ts.into_inner();
-        prewrite_req.lock_ttl = prewrite_req.start_version + 1;
-        prewrite_req.for_update_ts = for_update_ts.into_inner();
-        prewrite_req.mut_is_pessimistic_lock().push(true);
-        let prewrite_resp = self
-            .get_tikv_client(region_id)
-            .kv_prewrite(&prewrite_req)
-            .unwrap();
-        assert!(
-            !prewrite_resp.has_region_error(),
-            "{:?}",
-            prewrite_resp.get_region_error()
-        );
-        assert!(
-            prewrite_resp.errors.is_empty(),
-            "{:?}",
-            prewrite_resp.get_errors()
-        );
-    }
-
-    pub fn async_kv_commit(
-        &mut self,
-        region_id: u64,
-        keys: Vec<Vec<u8>>,
-        start_ts: TimeStamp,
-        commit_ts: TimeStamp,
-    ) -> ClientUnaryReceiver<CommitResponse> {
-        let mut commit_req = CommitRequest::default();
-        commit_req.set_context(self.get_context(region_id));
-        commit_req.start_version = start_ts.into_inner();
-        commit_req.set_keys(keys.into_iter().collect());
-        commit_req.commit_version = commit_ts.into_inner();
-        self.get_tikv_client(region_id)
-            .kv_commit_async(&commit_req)
-            .unwrap()
-    }
-
-    pub fn get_context(&mut self, region_id: u64) -> Context {
-        let epoch = self.cluster.get_region_epoch(region_id);
-        let leader = self.cluster.leader_of_region(region_id).unwrap();
-        let mut context = Context::default();
-        context.set_region_id(region_id);
-        context.set_peer(leader);
-        context.set_region_epoch(epoch);
-        context
-    }
-
-    pub fn get_tikv_client(&mut self, region_id: u64) -> &TikvClient {
-        let leader = self.cluster.leader_of_region(region_id).unwrap();
-        let store_id = leader.get_store_id();
+    fn get_client_from_store_id(&mut self, store_id: u64) -> &TikvClient {
         let addr = self.cluster.sim.rl().get_addr(store_id);
         let env = self.env.clone();
-        self.tikv_cli
-            .entry(leader.get_store_id())
-            .or_insert_with(|| {
-                let channel = ChannelBuilder::new(env).connect(&addr);
-                TikvClient::new(channel)
-            })
+        self.tikv_cli.entry(store_id).or_insert_with(|| {
+            let channel = ChannelBuilder::new(env).connect(&addr);
+            TikvClient::new(channel)
+        })
     }
 
-    pub fn set_tso(&self, ts: impl Into<TimeStamp>) {
-        self.cluster.pd_client.set_tso(ts.into());
-    }
-
-    pub fn region_resolved_ts(&mut self, region_id: u64) -> Option<TimeStamp> {
-        let leader = self.cluster.leader_of_region(region_id)?;
-        let meta = self.cluster.store_metas[&leader.store_id].lock().unwrap();
-        Some(
-            meta.region_read_progress
-                .get_safe_ts(&region_id)
-                .unwrap()
-                .into(),
-        )
-    }
-
-    pub fn must_get_rts(&mut self, region_id: u64, rts: TimeStamp) {
-        for _ in 0..50 {
-            if let Some(ts) = self.region_resolved_ts(region_id) {
-                if rts == ts {
-                    return;
-                }
-            }
-            sleep_ms(100)
-        }
-        panic!("fail to get same ts after 50 trys");
-    }
-
-    pub fn must_get_rts_ge(&mut self, region_id: u64, rts: TimeStamp) {
-        for _ in 0..50 {
-            if let Some(ts) = self.region_resolved_ts(region_id) {
-                if rts < ts {
-                    return;
-                }
-            }
-            sleep_ms(100)
-        }
-        panic!("fail to get greater ts after 50 trys");
-    }
-
-    fn get_client_from_store_id(&mut self, store_id: u64) -> &TikvClient  {
-        let addr = self.cluster.sim.rl().get_addr(store_id);
-        let env = self.env.clone();
-        self.tikv_cli
-            .entry(store_id)
-            .or_insert_with(|| {
-                let channel = ChannelBuilder::new(env).connect(&addr);
-                TikvClient::new(channel)
-            })
-    }
-
-    pub fn must_check_leader(&mut self, region_id: u64, resolved_ts: TimeStamp, applied_index: u64, store_id: u64) {
+    pub fn must_check_leader(
+        &mut self,
+        region_id: u64,
+        resolved_ts: TimeStamp,
+        applied_index: u64,
+        store_id: u64,
+    ) {
         let mut leader_info = LeaderInfo::default();
         leader_info.set_region_id(region_id);
         let mut read_state = ReadState::default();
@@ -313,20 +81,21 @@ impl TestSuite {
         req.set_regions(regions.into());
         req.set_ts(resolved_ts.into_inner());
 
-        let _check_leader_resp = self.get_client_from_store_id(store_id).check_leader(&req).unwrap();
+        let _check_leader_resp = self
+            .get_client_from_store_id(store_id)
+            .check_leader(&req)
+            .unwrap();
     }
 }
 
-
-
 #[test]
-fn test_resolved_ts_basic() {
+fn test_safe_ts_basic() {
     let mut suite = TestSuite::new(1);
     let physical_time = 646454654654;
-    unsafe {
-        suite.cluster.set_expected_safe_ts(physical_time, physical_time);
-    }
-    suite.must_check_leader(1, TimeStamp::compose(physical_time,10), 1, 1);
+    suite
+        .cluster
+        .set_expected_safe_ts(physical_time, physical_time);
+    suite.must_check_leader(1, TimeStamp::compose(physical_time, 10), 1, 1);
 
     suite.stop();
 }

--- a/tests/proxy/server_cluster_test.rs
+++ b/tests/proxy/server_cluster_test.rs
@@ -1,0 +1,332 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{sync::*, time::Duration};
+
+use collections::HashMap;
+use concurrency_manager::ConcurrencyManager;
+use engine_rocks::RocksSnapshot;
+use grpcio::{ChannelBuilder, ClientUnaryReceiver, Environment};
+use kvproto::{kvrpcpb::*, tikvpb::TikvClient};
+use online_config::ConfigValue;
+use raftstore::coprocessor::CoprocessorHost;
+use new_mock_engine_store::{*, mock_cluster::{sleep_ms, get_global_engine_helper_set}, server::{new_server_cluster, ServerCluster}};
+use tikv::config::ResolvedTsConfig;
+use tikv_util::{worker::LazyWorker, HandyRwLock};
+use txn_types::TimeStamp;
+static INIT: Once = Once::new();
+
+pub fn init() {
+    INIT.call_once(test_util::setup_for_ci);
+}
+
+pub struct TestSuite {
+    pub cluster: Cluster<ServerCluster>,
+    tikv_cli: HashMap<u64, TikvClient>,
+
+    env: Arc<Environment>,
+}
+
+impl TestSuite {
+    pub fn new(count: usize) -> Self {
+        let mut cluster = new_server_cluster(1, count);
+        Self::with_cluster(count, cluster)
+    }
+
+    pub fn with_cluster(count: usize, mut cluster: Cluster<ServerCluster>) -> Self {
+        init();
+        let pd_cli = cluster.pd_client.clone();
+
+        cluster.run();
+
+        TestSuite {
+            cluster,
+            tikv_cli: HashMap::default(),
+            env: Arc::new(Environment::new(1)),
+        }
+    }
+
+    pub fn stop(mut self) {
+        self.cluster.shutdown();
+    }
+
+    pub fn must_kv_prewrite(
+        &mut self,
+        region_id: u64,
+        muts: Vec<Mutation>,
+        pk: Vec<u8>,
+        ts: TimeStamp,
+    ) {
+        let mut prewrite_req = PrewriteRequest::default();
+        prewrite_req.set_context(self.get_context(region_id));
+        prewrite_req.set_mutations(muts.into_iter().collect());
+        prewrite_req.primary_lock = pk;
+        prewrite_req.start_version = ts.into_inner();
+        prewrite_req.lock_ttl = prewrite_req.start_version + 1;
+        let prewrite_resp = self
+            .get_tikv_client(region_id)
+            .kv_prewrite(&prewrite_req)
+            .unwrap();
+        assert!(
+            !prewrite_resp.has_region_error(),
+            "{:?}",
+            prewrite_resp.get_region_error()
+        );
+        assert!(
+            prewrite_resp.errors.is_empty(),
+            "{:?}",
+            prewrite_resp.get_errors()
+        );
+    }
+
+    pub fn must_kv_commit(
+        &mut self,
+        region_id: u64,
+        keys: Vec<Vec<u8>>,
+        start_ts: TimeStamp,
+        commit_ts: TimeStamp,
+    ) {
+        let mut commit_req = CommitRequest::default();
+        commit_req.set_context(self.get_context(region_id));
+        commit_req.start_version = start_ts.into_inner();
+        commit_req.set_keys(keys.into_iter().collect());
+        commit_req.commit_version = commit_ts.into_inner();
+        let commit_resp = self
+            .get_tikv_client(region_id)
+            .kv_commit(&commit_req)
+            .unwrap();
+        assert!(
+            !commit_resp.has_region_error(),
+            "{:?}",
+            commit_resp.get_region_error()
+        );
+        assert!(!commit_resp.has_error(), "{:?}", commit_resp.get_error());
+    }
+
+    pub fn must_kv_rollback(&mut self, region_id: u64, keys: Vec<Vec<u8>>, start_ts: TimeStamp) {
+        let mut rollback_req = BatchRollbackRequest::default();
+        rollback_req.set_context(self.get_context(region_id));
+        rollback_req.start_version = start_ts.into_inner();
+        rollback_req.set_keys(keys.into_iter().collect());
+        let rollback_resp = self
+            .get_tikv_client(region_id)
+            .kv_batch_rollback(&rollback_req)
+            .unwrap();
+        assert!(
+            !rollback_resp.has_region_error(),
+            "{:?}",
+            rollback_resp.get_region_error()
+        );
+        assert!(
+            !rollback_resp.has_error(),
+            "{:?}",
+            rollback_resp.get_error()
+        );
+    }
+
+    pub fn must_check_txn_status(
+        &mut self,
+        region_id: u64,
+        primary_key: Vec<u8>,
+        lock_ts: TimeStamp,
+        caller_start_ts: TimeStamp,
+        current_ts: TimeStamp,
+        rollback_if_not_exist: bool,
+    ) -> Action {
+        let mut req = CheckTxnStatusRequest::default();
+        req.set_context(self.get_context(region_id));
+        req.set_primary_key(primary_key);
+        req.set_lock_ts(lock_ts.into_inner());
+        req.set_caller_start_ts(caller_start_ts.into_inner());
+        req.set_current_ts(current_ts.into_inner());
+        req.set_rollback_if_not_exist(rollback_if_not_exist);
+        let resp = self
+            .get_tikv_client(region_id)
+            .kv_check_txn_status(&req)
+            .unwrap();
+        assert!(!resp.has_region_error(), "{:?}", resp.get_region_error());
+        assert!(!resp.has_error(), "{:?}", resp.get_error());
+        resp.get_action()
+    }
+
+    pub fn must_acquire_pessimistic_lock(
+        &mut self,
+        region_id: u64,
+        muts: Vec<Mutation>,
+        pk: Vec<u8>,
+        start_ts: TimeStamp,
+        for_update_ts: TimeStamp,
+    ) {
+        let mut lock_req = PessimisticLockRequest::default();
+        lock_req.set_context(self.get_context(region_id));
+        lock_req.set_mutations(muts.into_iter().collect());
+        lock_req.start_version = start_ts.into_inner();
+        lock_req.for_update_ts = for_update_ts.into_inner();
+        lock_req.primary_lock = pk;
+        let lock_resp = self
+            .get_tikv_client(region_id)
+            .kv_pessimistic_lock(&lock_req)
+            .unwrap();
+        assert!(
+            !lock_resp.has_region_error(),
+            "{:?}",
+            lock_resp.get_region_error()
+        );
+        assert!(
+            lock_resp.get_errors().is_empty(),
+            "{:?}",
+            lock_resp.get_errors()
+        );
+    }
+
+    pub fn must_kv_pessimistic_prewrite(
+        &mut self,
+        region_id: u64,
+        muts: Vec<Mutation>,
+        pk: Vec<u8>,
+        ts: TimeStamp,
+        for_update_ts: TimeStamp,
+    ) {
+        let mut prewrite_req = PrewriteRequest::default();
+        prewrite_req.set_context(self.get_context(region_id));
+        prewrite_req.set_mutations(muts.into_iter().collect());
+        prewrite_req.primary_lock = pk;
+        prewrite_req.start_version = ts.into_inner();
+        prewrite_req.lock_ttl = prewrite_req.start_version + 1;
+        prewrite_req.for_update_ts = for_update_ts.into_inner();
+        prewrite_req.mut_is_pessimistic_lock().push(true);
+        let prewrite_resp = self
+            .get_tikv_client(region_id)
+            .kv_prewrite(&prewrite_req)
+            .unwrap();
+        assert!(
+            !prewrite_resp.has_region_error(),
+            "{:?}",
+            prewrite_resp.get_region_error()
+        );
+        assert!(
+            prewrite_resp.errors.is_empty(),
+            "{:?}",
+            prewrite_resp.get_errors()
+        );
+    }
+
+    pub fn async_kv_commit(
+        &mut self,
+        region_id: u64,
+        keys: Vec<Vec<u8>>,
+        start_ts: TimeStamp,
+        commit_ts: TimeStamp,
+    ) -> ClientUnaryReceiver<CommitResponse> {
+        let mut commit_req = CommitRequest::default();
+        commit_req.set_context(self.get_context(region_id));
+        commit_req.start_version = start_ts.into_inner();
+        commit_req.set_keys(keys.into_iter().collect());
+        commit_req.commit_version = commit_ts.into_inner();
+        self.get_tikv_client(region_id)
+            .kv_commit_async(&commit_req)
+            .unwrap()
+    }
+
+    pub fn get_context(&mut self, region_id: u64) -> Context {
+        let epoch = self.cluster.get_region_epoch(region_id);
+        let leader = self.cluster.leader_of_region(region_id).unwrap();
+        let mut context = Context::default();
+        context.set_region_id(region_id);
+        context.set_peer(leader);
+        context.set_region_epoch(epoch);
+        context
+    }
+
+    pub fn get_tikv_client(&mut self, region_id: u64) -> &TikvClient {
+        let leader = self.cluster.leader_of_region(region_id).unwrap();
+        let store_id = leader.get_store_id();
+        let addr = self.cluster.sim.rl().get_addr(store_id);
+        let env = self.env.clone();
+        self.tikv_cli
+            .entry(leader.get_store_id())
+            .or_insert_with(|| {
+                let channel = ChannelBuilder::new(env).connect(&addr);
+                TikvClient::new(channel)
+            })
+    }
+
+    pub fn set_tso(&self, ts: impl Into<TimeStamp>) {
+        self.cluster.pd_client.set_tso(ts.into());
+    }
+
+    pub fn region_resolved_ts(&mut self, region_id: u64) -> Option<TimeStamp> {
+        let leader = self.cluster.leader_of_region(region_id)?;
+        let meta = self.cluster.store_metas[&leader.store_id].lock().unwrap();
+        Some(
+            meta.region_read_progress
+                .get_safe_ts(&region_id)
+                .unwrap()
+                .into(),
+        )
+    }
+
+    pub fn must_get_rts(&mut self, region_id: u64, rts: TimeStamp) {
+        for _ in 0..50 {
+            if let Some(ts) = self.region_resolved_ts(region_id) {
+                if rts == ts {
+                    return;
+                }
+            }
+            sleep_ms(100)
+        }
+        panic!("fail to get same ts after 50 trys");
+    }
+
+    pub fn must_get_rts_ge(&mut self, region_id: u64, rts: TimeStamp) {
+        for _ in 0..50 {
+            if let Some(ts) = self.region_resolved_ts(region_id) {
+                if rts < ts {
+                    return;
+                }
+            }
+            sleep_ms(100)
+        }
+        panic!("fail to get greater ts after 50 trys");
+    }
+
+    fn get_client_from_store_id(&mut self, store_id: u64) -> &TikvClient  {
+        let addr = self.cluster.sim.rl().get_addr(store_id);
+        let env = self.env.clone();
+        self.tikv_cli
+            .entry(store_id)
+            .or_insert_with(|| {
+                let channel = ChannelBuilder::new(env).connect(&addr);
+                TikvClient::new(channel)
+            })
+    }
+
+    pub fn must_check_leader(&mut self, region_id: u64, resolved_ts: TimeStamp, applied_index: u64, store_id: u64) {
+        let mut leader_info = LeaderInfo::default();
+        leader_info.set_region_id(region_id);
+        let mut read_state = ReadState::default();
+        read_state.set_applied_index(applied_index);
+        read_state.set_safe_ts(resolved_ts.into_inner());
+        leader_info.set_read_state(read_state);
+
+        let mut req = CheckLeaderRequest::default();
+        let regions = vec![leader_info];
+        req.set_regions(regions.into());
+        req.set_ts(resolved_ts.into_inner());
+
+        let _check_leader_resp = self.get_client_from_store_id(store_id).check_leader(&req).unwrap();
+    }
+}
+
+
+
+#[test]
+fn test_resolved_ts_basic() {
+    let mut suite = TestSuite::new(1);
+    let physical_time = 646454654654;
+    unsafe {
+        suite.cluster.set_expected_safe_ts(physical_time, physical_time);
+    }
+    suite.must_check_leader(1, TimeStamp::compose(physical_time,10), 1, 1);
+
+    suite.stop();
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:
Currently, TiFlash proxy use [node.rs](https://github.com/pingcap/tidb-engine-ext/blob/raftstore-proxy/new-mock-engine-store/src/node.rs) to simulate `raftstore`. But for grpc which is not raft message, such as `check_leader`, can't be tested in current UT framework.
### What is changed and how it works?
Introduce ServerCluster test framework and test `check_leader` RPC.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
