### PR TITLE
Fix advertise status addr

### DIFF
--- a/components/engine_store_ffi/src/lib.rs
+++ b/components/engine_store_ffi/src/lib.rs
@@ -1004,7 +1004,7 @@ impl EngineStoreServerHelper {
                 self.inner,
                 region_id,
                 if force_persist {
-                    error!("we don't support try_flush_data for now");
+                    tikv_util::error!("we don't support try_flush_data for now");
                     2
                 } else {
                     if try_until_succeed { 1 } else { 0 }

--- a/components/engine_store_ffi/src/lib.rs
+++ b/components/engine_store_ffi/src/lib.rs
@@ -1004,6 +1004,7 @@ impl EngineStoreServerHelper {
                 self.inner,
                 region_id,
                 if force_persist {
+                    error!("we don't support try_flush_data for now");
                     2
                 } else {
                     if try_until_succeed { 1 } else { 0 }

--- a/components/proxy_server/src/config.rs
+++ b/components/proxy_server/src/config.rs
@@ -69,7 +69,7 @@ impl Default for ServerConfig {
             engine_store_git_hash: String::default(),
             addr: TIFLASH_DEFAULT_LISTENING_ADDR.to_string(),
             status_addr: TIFLASH_DEFAULT_STATUS_ADDR.to_string(),
-            advertise_status_addr: TIFLASH_DEFAULT_STATUS_ADDR.to_string(),
+            advertise_status_addr: TIFLASH_DEFAULT_ADVERTISE_LISTENING_ADDR.to_string(),
             advertise_addr: TIFLASH_DEFAULT_ADVERTISE_LISTENING_ADDR.to_string(),
         }
     }

--- a/components/proxy_server/src/config.rs
+++ b/components/proxy_server/src/config.rs
@@ -317,7 +317,7 @@ pub fn setup_default_tikv_config(default: &mut TikvConfig) {
     default.server.addr = TIFLASH_DEFAULT_LISTENING_ADDR.to_string();
     default.server.advertise_addr = TIFLASH_DEFAULT_ADVERTISE_LISTENING_ADDR.to_string();
     default.server.status_addr = TIFLASH_DEFAULT_STATUS_ADDR.to_string();
-    default.server.advertise_status_addr = TIFLASH_DEFAULT_STATUS_ADDR.to_string();
+    default.server.advertise_status_addr = TIFLASH_DEFAULT_ADVERTISE_LISTENING_ADDR.to_string();
     // Do not add here, try use `address_proxy_config`.
 }
 

--- a/tests/proxy/normal.rs
+++ b/tests/proxy/normal.rs
@@ -30,7 +30,8 @@ use proxy_server::{
     config::{
         address_proxy_config, ensure_no_common_unrecognized_keys, get_last_config,
         memory_limit_for_cf, setup_default_tikv_config, validate_and_persist_config,
-        TIFLASH_DEFAULT_LISTENING_ADDR, TIFLASH_DEFAULT_STATUS_ADDR,
+        TIFLASH_DEFAULT_ADVERTISE_LISTENING_ADDR, TIFLASH_DEFAULT_LISTENING_ADDR,
+        TIFLASH_DEFAULT_STATUS_ADDR,
     },
     proxy::gen_tikv_config,
 };
@@ -331,7 +332,7 @@ mod config {
         assert_eq!(config.server.status_addr, TIFLASH_DEFAULT_STATUS_ADDR);
         assert_eq!(
             config.server.advertise_status_addr,
-            TIFLASH_DEFAULT_LISTENING_ADDR
+            TIFLASH_DEFAULT_ADVERTISE_LISTENING_ADDR
         );
         assert_eq!(
             config.raft_store.region_worker_tick_interval.as_millis(),
@@ -371,7 +372,7 @@ mod config {
         assert_eq!(config.server.status_addr, TIFLASH_DEFAULT_STATUS_ADDR);
         assert_eq!(
             config.server.advertise_status_addr,
-            TIFLASH_DEFAULT_LISTENING_ADDR
+            TIFLASH_DEFAULT_ADVERTISE_LISTENING_ADDR
         );
         assert_eq!(
             config.raft_store.region_worker_tick_interval.as_millis(),

--- a/tests/proxy/normal.rs
+++ b/tests/proxy/normal.rs
@@ -331,7 +331,7 @@ mod config {
         assert_eq!(config.server.status_addr, TIFLASH_DEFAULT_STATUS_ADDR);
         assert_eq!(
             config.server.advertise_status_addr,
-            TIFLASH_DEFAULT_STATUS_ADDR
+            TIFLASH_DEFAULT_LISTENING_ADDR
         );
         assert_eq!(
             config.raft_store.region_worker_tick_interval.as_millis(),
@@ -371,7 +371,7 @@ mod config {
         assert_eq!(config.server.status_addr, TIFLASH_DEFAULT_STATUS_ADDR);
         assert_eq!(
             config.server.advertise_status_addr,
-            TIFLASH_DEFAULT_STATUS_ADDR
+            TIFLASH_DEFAULT_LISTENING_ADDR
         );
         assert_eq!(
             config.raft_store.region_worker_tick_interval.as_millis(),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

The config is like
```
log-file = "/Users/calvin/.tiup/data/advertise/tiflash-0/log/tiflash_tikv.log"

[rocksdb]
wal-dir = ""
max-open-files = 256

[security]
ca-path = ""
cert-path = ""
key-path = ""

[server]
addr = "0.0.0.0:20170"
advertise-addr = "127.0.0.1:20170"
engine-addr = "127.0.0.1:3930"
status-addr = "0.0.0.0:20277"

[storage]
data-dir = "/Users/calvin/.tiup/data/advertise/tiflash-0/flash"

[raftdb]
max-open-files = 256

```

![94ed2eb9-ec12-4f68-af4c-f8245ffe1aa6](https://user-images.githubusercontent.com/5670241/198561545-8297edf4-af6c-45dc-9137-4fe7ccb630ef.jpeg)

While the error one is 
<img width="574" alt="image" src="https://user-images.githubusercontent.com/5670241/198564345-6e51000e-0db6-459f-99b8-234aa8285046.png">


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
