### PR TITLE
set status-thread-pool-size to 2 by default

### DIFF
--- a/proxy_server/src/config.rs
+++ b/proxy_server/src/config.rs
@@ -393,6 +393,7 @@ pub fn address_proxy_config(config: &mut TikvConfig, proxy_config: &ProxyConfig)
 
     config.server.background_thread_count = proxy_config.server.background_thread_count;
     config.import.num_threads = proxy_config.import.num_threads;
+    config.server.status_thread_pool_size = proxy_config.server.status_thread_pool_size;
 }
 
 pub fn validate_and_persist_config(config: &mut TikvConfig, persist: bool) {

--- a/proxy_server/src/config.rs
+++ b/proxy_server/src/config.rs
@@ -61,6 +61,7 @@ pub struct ServerConfig {
     pub advertise_addr: String,
     #[online_config(skip)]
     pub background_thread_count: usize,
+    pub status_thread_pool_size: usize,
 }
 
 impl Default for ServerConfig {
@@ -76,6 +77,7 @@ impl Default for ServerConfig {
             advertise_status_addr: TIFLASH_DEFAULT_ADVERTISE_LISTENING_ADDR.to_string(),
             advertise_addr: TIFLASH_DEFAULT_ADVERTISE_LISTENING_ADDR.to_string(),
             background_thread_count,
+            status_thread_pool_size: 2,
         }
     }
 }

--- a/proxy_server/src/run.rs
+++ b/proxy_server/src/run.rs
@@ -1559,7 +1559,7 @@ impl<ER: RaftEngine> TiKvServer<ER> {
                 engine_store_ffi::gen_engine_store_server_helper(
                     self.engine_store_server_helper_ptr,
                 ),
-                self.config.server.status_thread_pool_size,
+                self.proxy_config.server.status_thread_pool_size,
                 self.cfg_controller.take().unwrap(),
                 Arc::new(self.config.security.clone()),
                 self.router.clone(),

--- a/proxy_server/src/run.rs
+++ b/proxy_server/src/run.rs
@@ -1559,7 +1559,7 @@ impl<ER: RaftEngine> TiKvServer<ER> {
                 engine_store_ffi::gen_engine_store_server_helper(
                     self.engine_store_server_helper_ptr,
                 ),
-                self.proxy_config.server.status_thread_pool_size,
+                self.config.server.status_thread_pool_size,
                 self.cfg_controller.take().unwrap(),
                 Arc::new(self.config.security.clone()),
                 self.router.clone(),

--- a/proxy_tests/proxy/config.rs
+++ b/proxy_tests/proxy/config.rs
@@ -118,6 +118,7 @@ fn test_config_proxy_default_no_config_item() {
     );
 
     assert_eq!(config.import.num_threads, 4);
+    assert_eq!(config.server.status_thread_pool_size, 2);
 }
 
 /// We test if the engine-label is set properly.


### PR DESCRIPTION
Signed-off-by: hehechen <awd123456sss@gmail.com>

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/6347

Problem Summary:
It seems that the overhead of `dwarf` is larger than that of `frame pointer.` So set `status-thread-pool-size `to 2 by default to avoid the `status_server` thread being stuck and unable to process the http request from prometheus.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Enable `continuous profiling`, and then `go-tpc ch --warehouses 1500 -T 100 -t 1 --time 90m  --queries "q1"` and check if the metrics abnormal.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
