### PR TITLE
patch backtrace-rs to increase MAPPINGS_CACHE_SIZE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,8 +440,7 @@ dependencies = [
 [[package]]
 name = "backtrace"
 version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+source = "git+https://github.com/hehechen/backtrace-rs?branch=v0.3.61#d0aeebbea2298174e4c6edd3d1e54bda0e6624e4"
 dependencies = [
  "addr2line",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,8 @@ cmake = { git = "https://github.com/rust-lang/cmake-rs" }
 # This is a workaround for cargo can't resolving the this patch in yatp.
 crossbeam-deque = { git = "https://github.com/crossbeam-rs/crossbeam", rev = "41ed3d948720f26149b2ebeaf58fe8a193134056" }
 
+# remove this when https://github.com/rust-lang/backtrace-rs/pull/503 is merged.
+backtrace = { git = 'https://github.com/hehechen/backtrace-rs', branch = "v0.3.61" }
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229b2c1fcc44118bef7eff127128" }
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to


### PR DESCRIPTION
Signed-off-by: hehechen <awd123456sss@gmail.com>

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/14025, https://github.com/pingcap/tiflash/issues/6347

Problem Summary:
[The overhead of dwarf resolving symbol is larger than that of frame pointer](https://github.com/pingcap/tiflash/issues/6347). 
The[ root cause](https://github.com/pingcap/tiflash/issues/6347#issuecomment-1333038382) is that the backtrace of DWARF is deeper than that of frame pointer. So DWARF need to resolve more shared libraries when resolving symbols. But [the capacity of lib cache in backtrace-rs is only 4](https://github.com/rust-lang/backtrace-rs/blob/5be2e8ba9cf6e391c5fa45219fc091b4075eb6be/src/symbolize/gimli.rs#L55), so cache miss will occurs frequently in DWARF scenarios.
I created a PR to https://github.com/rust-lang/backtrace-rs/pull/503, but it has not been discussed and merged. I think we can patch [backtrace-rs](https://github.com/rust-lang/backtrace-rs) and modify MAPPINGS_CACHE_SIZE to 10.
### What is changed and how it works?
Patch backtrace-rs to increase MAPPINGS_CACHE_SIZE
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
[Test in TiFlash proxy](https://github.com/pingcap/tiflash/issues/6347#issuecomment-1333038382), 10 seconds profiling time reduced from 80 seconds to 11 seconds.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
