### PR TITLE
Decouple FFI with engine_tiflash

### DIFF
--- a/engine_store_ffi/src/ffi/mod.rs
+++ b/engine_store_ffi/src/ffi/mod.rs
@@ -18,6 +18,7 @@ pub mod engine_store_helper_impls;
 pub(crate) mod lock_cf_reader;
 // FFI directly related with RaftStoreProxyFFIHelper.
 pub mod raftstore_proxy;
+pub mod raftstore_proxy_engine;
 pub mod raftstore_proxy_helper_impls;
 pub mod read_index_helper;
 pub mod sst_reader_impls;
@@ -28,7 +29,7 @@ pub use engine_tiflash::EngineStoreConfig;
 pub use self::{
     basic_ffi_impls::*, domain_impls::*, encryption_impls::*, engine_store_helper_impls::*,
     interfaces::root::DB as interfaces_ffi, lock_cf_reader::*, raftstore_proxy::*,
-    raftstore_proxy_helper_impls::*, sst_reader_impls::*,
+    raftstore_proxy_engine::*, raftstore_proxy_helper_impls::*, sst_reader_impls::*,
 };
 
 #[allow(clippy::wrong_self_convention)]

--- a/engine_store_ffi/src/ffi/raftstore_proxy.rs
+++ b/engine_store_ffi/src/ffi/raftstore_proxy.rs
@@ -38,7 +38,18 @@ impl RaftStoreProxy {
     }
 }
 
-impl RaftStoreProxyFFI<TiFlashEngine> for RaftStoreProxy {
+impl RaftStoreProxy {
+    pub fn set_kv_engine(&mut self, kv_engine: Option<TiFlashEngine>) {
+        let mut lock = self.kv_engine.write().unwrap();
+        *lock = kv_engine;
+    }
+
+    pub fn kv_engine(&self) -> &RwLock<Option<TiFlashEngine>> {
+        &self.kv_engine
+    }
+}
+
+impl RaftStoreProxyFFI for RaftStoreProxy {
     fn maybe_read_index_client(&self) -> &Option<Box<dyn read_index_helper::ReadIndex>> {
         &self.read_index_client
     }
@@ -53,15 +64,6 @@ impl RaftStoreProxyFFI<TiFlashEngine> for RaftStoreProxy {
 
     fn maybe_key_manager(&self) -> &Option<Arc<DataKeyManager>> {
         &self.key_manager
-    }
-
-    fn set_kv_engine(&mut self, kv_engine: Option<TiFlashEngine>) {
-        let mut lock = self.kv_engine.write().unwrap();
-        *lock = kv_engine;
-    }
-
-    fn kv_engine(&self) -> &RwLock<Option<TiFlashEngine>> {
-        &self.kv_engine
     }
 
     fn set_status(&mut self, s: RaftProxyStatus) {

--- a/engine_store_ffi/src/ffi/raftstore_proxy.rs
+++ b/engine_store_ffi/src/ffi/raftstore_proxy.rs
@@ -13,13 +13,14 @@ use super::{
     raftstore_proxy_helper_impls::*,
     read_index_helper,
 };
-use crate::TiFlashEngine;
+
+pub type Eng = Box<dyn RaftStoreProxyEngineTrait + Sync + Send>;
 
 pub struct RaftStoreProxy {
     status: AtomicU8,
     key_manager: Option<Arc<DataKeyManager>>,
     read_index_client: Option<Box<dyn read_index_helper::ReadIndex>>,
-    kv_engine: RwLock<Option<TiFlashEngine>>,
+    raftstore_proxy_engine: RwLock<Option<Eng>>,
 }
 
 impl RaftStoreProxy {
@@ -27,26 +28,50 @@ impl RaftStoreProxy {
         status: AtomicU8,
         key_manager: Option<Arc<DataKeyManager>>,
         read_index_client: Option<Box<dyn read_index_helper::ReadIndex>>,
-        kv_engine: RwLock<Option<TiFlashEngine>>,
+        raftstore_proxy_engine: Option<Eng>,
     ) -> Self {
         RaftStoreProxy {
             status,
             key_manager,
             read_index_client,
-            kv_engine,
+            raftstore_proxy_engine: RwLock::new(raftstore_proxy_engine),
         }
     }
 }
 
 impl RaftStoreProxy {
-    pub fn set_kv_engine(&mut self, kv_engine: Option<TiFlashEngine>) {
-        let mut lock = self.kv_engine.write().unwrap();
+    pub fn set_kv_engine(&mut self, kv_engine: Option<Eng>) {
+        let mut lock = self.raftstore_proxy_engine.write().unwrap();
         *lock = kv_engine;
     }
 
-    pub fn kv_engine(&self) -> &RwLock<Option<TiFlashEngine>> {
-        &self.kv_engine
+    // Only for test
+    pub fn kv_engine(&self) -> &RwLock<Option<Eng>> {
+        &self.raftstore_proxy_engine
     }
+
+    pub fn get_value_cf(
+        &self,
+        cf: &str,
+        key: &[u8],
+        cb: &mut dyn FnMut(Result<Option<&[u8]>, String>),
+    ) {
+        let kv_engine_lock = self.raftstore_proxy_engine.read().unwrap();
+        let kv_engine = kv_engine_lock.as_ref();
+        if kv_engine.is_none() {
+            cb(Err("KV engine is not initialized".to_string()));
+            return;
+        }
+        kv_engine.unwrap().get_value_cf(cf, key, cb)
+    }
+}
+
+pub trait RaftStoreProxyEngineTrait {
+    fn get_value_cf(&self, cf: &str, key: &[u8], cb: &mut dyn FnMut(Result<Option<&[u8]>, String>));
+    // Only for tests
+    fn engine_store_server_helper(&self) -> isize;
+    // Only for tests
+    fn set_engine_store_server_helper(&mut self, _: isize);
 }
 
 impl RaftStoreProxyFFI for RaftStoreProxy {
@@ -68,31 +93,6 @@ impl RaftStoreProxyFFI for RaftStoreProxy {
 
     fn set_status(&mut self, s: RaftProxyStatus) {
         self.status.store(s as u8, Ordering::SeqCst);
-    }
-
-    fn get_value_cf<F>(&self, cf: &str, key: &[u8], cb: F)
-    where
-        F: FnOnce(Result<Option<&[u8]>, String>),
-    {
-        let kv_engine_lock = self.kv_engine.read().unwrap();
-        let kv_engine = kv_engine_lock.as_ref();
-        if kv_engine.is_none() {
-            cb(Err("KV engine is not initialized".to_string()));
-            return;
-        }
-        let value = kv_engine.unwrap().get_value_cf(cf, key);
-        match value {
-            Ok(v) => {
-                if let Some(x) = v {
-                    cb(Ok(Some(&x)));
-                } else {
-                    cb(Ok(None));
-                }
-            }
-            Err(e) => {
-                cb(Err(format!("{}", e)));
-            }
-        }
     }
 }
 

--- a/engine_store_ffi/src/ffi/raftstore_proxy.rs
+++ b/engine_store_ffi/src/ffi/raftstore_proxy.rs
@@ -1,5 +1,5 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
-
+#![allow(clippy::type_complexity)]
 use std::sync::{
     atomic::{AtomicU8, Ordering},
     Arc, RwLock,

--- a/engine_store_ffi/src/ffi/raftstore_proxy.rs
+++ b/engine_store_ffi/src/ffi/raftstore_proxy.rs
@@ -6,7 +6,6 @@ use std::sync::{
 };
 
 use encryption::DataKeyManager;
-use engine_traits::Peekable;
 
 use super::{
     interfaces_ffi::{ConstRawVoidPtr, RaftProxyStatus, RaftStoreProxyPtr},

--- a/engine_store_ffi/src/ffi/raftstore_proxy_engine.rs
+++ b/engine_store_ffi/src/ffi/raftstore_proxy_engine.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+#![allow(clippy::type_complexity)]
 
 use engine_traits::Peekable;
 

--- a/engine_store_ffi/src/ffi/raftstore_proxy_engine.rs
+++ b/engine_store_ffi/src/ffi/raftstore_proxy_engine.rs
@@ -1,0 +1,61 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc, RwLock,
+};
+
+use encryption::DataKeyManager;
+use engine_traits::Peekable;
+
+use super::{
+    interfaces_ffi::{ConstRawVoidPtr, RaftProxyStatus, RaftStoreProxyPtr},
+    raftstore_proxy::*,
+    raftstore_proxy_helper_impls::*,
+};
+use crate::TiFlashEngine;
+
+pub struct RaftStoreProxyEngine {
+    pub kv_engine: TiFlashEngine,
+}
+
+impl RaftStoreProxyEngine {
+    pub fn from_tiflash_engine(kv: TiFlashEngine) -> Option<Eng> {
+        let e = Self { kv_engine: kv };
+        Some(Box::new(e))
+    }
+}
+
+impl RaftStoreProxyEngineTrait for RaftStoreProxyEngine {
+    fn get_value_cf(
+        &self,
+        cf: &str,
+        key: &[u8],
+        cb: &mut dyn FnMut(Result<Option<&[u8]>, String>),
+    ) {
+        let value = self.kv_engine.get_value_cf(cf, key);
+        match value {
+            Ok(v) => {
+                if let Some(x) = v {
+                    cb(Ok(Some(&x)));
+                } else {
+                    cb(Ok(None));
+                }
+            }
+            Err(e) => {
+                cb(Err(format!("{}", e)));
+            }
+        }
+    }
+
+    fn engine_store_server_helper(&self) -> isize {
+        self.kv_engine.engine_store_server_helper
+    }
+
+    fn set_engine_store_server_helper(&mut self, x: isize) {
+        self.kv_engine.engine_store_server_helper = x;
+    }
+}
+
+unsafe impl Send for RaftStoreProxyEngine {}
+unsafe impl Sync for RaftStoreProxyEngine {}

--- a/engine_store_ffi/src/ffi/raftstore_proxy_engine.rs
+++ b/engine_store_ffi/src/ffi/raftstore_proxy_engine.rs
@@ -1,18 +1,8 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::sync::{
-    atomic::{AtomicU8, Ordering},
-    Arc, RwLock,
-};
-
-use encryption::DataKeyManager;
 use engine_traits::Peekable;
 
-use super::{
-    interfaces_ffi::{ConstRawVoidPtr, RaftProxyStatus, RaftStoreProxyPtr},
-    raftstore_proxy::*,
-    raftstore_proxy_helper_impls::*,
-};
+use super::raftstore_proxy::*;
 use crate::TiFlashEngine;
 
 pub struct RaftStoreProxyEngine {

--- a/engine_store_ffi/src/ffi/raftstore_proxy_helper_impls.rs
+++ b/engine_store_ffi/src/ffi/raftstore_proxy_helper_impls.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+#![allow(clippy::type_complexity)]
 
 use std::{
     pin::Pin,

--- a/engine_store_ffi/src/ffi/raftstore_proxy_helper_impls.rs
+++ b/engine_store_ffi/src/ffi/raftstore_proxy_helper_impls.rs
@@ -38,7 +38,7 @@ impl Clone for RaftStoreProxyPtr {
 
 impl Copy for RaftStoreProxyPtr {}
 
-pub trait RaftStoreProxyFFI<EK: engine_traits::KvEngine>: Sync {
+pub trait RaftStoreProxyFFI: Sync {
     fn status(&self) -> &AtomicU8;
     fn maybe_key_manager(&self) -> &Option<Arc<DataKeyManager>>;
     fn maybe_read_index_client(&self) -> &Option<Box<dyn read_index_helper::ReadIndex>>;
@@ -48,8 +48,8 @@ pub trait RaftStoreProxyFFI<EK: engine_traits::KvEngine>: Sync {
     fn get_value_cf<F>(&self, cf: &str, key: &[u8], cb: F)
     where
         F: FnOnce(Result<Option<&[u8]>, String>);
-    fn set_kv_engine(&mut self, kv_engine: Option<EK>);
-    fn kv_engine(&self) -> &RwLock<Option<EK>>;
+    // fn set_kv_engine(&mut self, kv_engine: Option<EK>);
+    // fn kv_engine(&self) -> &RwLock<Option<EK>>;
 }
 
 impl RaftStoreProxyFFIHelper {

--- a/engine_store_ffi/src/ffi/raftstore_proxy_helper_impls.rs
+++ b/engine_store_ffi/src/ffi/raftstore_proxy_helper_impls.rs
@@ -4,7 +4,7 @@ use std::{
     pin::Pin,
     sync::{
         atomic::{AtomicU8, Ordering},
-        Arc, RwLock,
+        Arc,
     },
     time,
 };

--- a/new-mock-engine-store/src/mock_cluster.rs
+++ b/new-mock-engine-store/src/mock_cluster.rs
@@ -187,7 +187,7 @@ impl<T: Simulator<TiFlashEngine>> Cluster<T> {
                 )),
                 None => None,
             },
-            std::sync::RwLock::new(Some(engines.kv.clone())),
+            engine_store_ffi::ffi::RaftStoreProxyEngine::from_tiflash_engine(engines.kv.clone()),
         ));
 
         let proxy_ref = proxy.as_ref();
@@ -211,7 +211,7 @@ impl<T: Simulator<TiFlashEngine>> Cluster<T> {
             .unwrap()
             .as_mut()
             .unwrap()
-            .engine_store_server_helper = engine_store_server_helper_ptr;
+            .set_engine_store_server_helper(engine_store_server_helper_ptr);
         let ffi_helper_set = FFIHelperSet {
             proxy,
             proxy_helper,
@@ -326,7 +326,7 @@ impl<T: Simulator<TiFlashEngine>> Cluster<T> {
                 .unwrap()
                 .as_mut()
                 .unwrap()
-                .engine_store_server_helper;
+                .engine_store_server_helper();
 
             let helper = engine_store_ffi::ffi::gen_engine_store_server_helper(helper_ptr);
             let ffi_hub = Arc::new(engine_store_ffi::engine::TiFlashFFIHub {

--- a/proxy_server/src/run.rs
+++ b/proxy_server/src/run.rs
@@ -146,7 +146,7 @@ pub fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(
             tikv.router.clone(),
             SysQuota::cpu_cores_quota() as usize * 2,
         ))),
-        std::sync::RwLock::new(None),
+        None,
     );
 
     let proxy_ref = &proxy;
@@ -183,7 +183,9 @@ pub fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(
         tikv.init_tiflash_engines(listener, engine_store_server_helper_ptr);
     tikv.init_engines(engines.clone());
     {
-        proxy.set_kv_engine(Some(engines.kv.clone()));
+        proxy.set_kv_engine(
+            engine_store_ffi::ffi::RaftStoreProxyEngine::from_tiflash_engine(engines.kv.clone()),
+        );
     }
     let server_config = tikv.init_servers::<F>();
     tikv.register_services();
@@ -252,7 +254,7 @@ fn run_impl_only_for_decryption<CER: ConfiguredRaftEngine, F: KvFormat>(
         AtomicU8::new(RaftProxyStatus::Idle as u8),
         encryption_key_manager.clone(),
         Option::None,
-        std::sync::RwLock::new(None),
+        None,
     );
 
     let proxy_ref = &proxy;

--- a/proxy_tests/proxy/region.rs
+++ b/proxy_tests/proxy/region.rs
@@ -112,13 +112,16 @@ fn test_get_region_local_state() {
 
                 ffi_set
                     .proxy
-                    .get_value_cf("none_cf", "123".as_bytes(), |value| {
+                    .get_value_cf("none_cf", "123".as_bytes(), &mut |value: Result<Option<&[u8]>, String>| {
                         let msg = value.unwrap_err();
                         assert_eq!(msg, "Storage Engine Status { code: IoError, sub_code: None, sev: NoError, state: \"cf none_cf not found\" }");
                     });
                 ffi_set
                     .proxy
-                    .get_value_cf("raft", "123".as_bytes(), |value| {
+                    .get_value_cf("raft", "123".as_bytes(), &mut |value: Result<
+                        Option<&[u8]>,
+                        String,
+                    >| {
                         let res = value.unwrap();
                         assert!(res.is_none());
                     });


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

That is, make FFI not rely on engine. We can now move all engine related codes into raftstore_proxy_engine.rs.

We can later move all other files in this mod to another crate.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
