### PR TITLE
[6.5] Use larger defaults for BR import

### DIFF
--- a/proxy_server/src/config.rs
+++ b/proxy_server/src/config.rs
@@ -43,7 +43,8 @@ impl Default for RaftstoreConfig {
             snap_handle_pool_size: (cpu_num * 0.7).clamp(2.0, 16.0) as usize,
             // This pool is used when handling ingest SST raft messages, e.g.
             // when using BR / lightning.
-            apply_low_priority_pool_size: (cpu_num * 0.3).clamp(2.0, 8.0) as usize,
+            // We want to use as more resource as possible when doing BR restore.
+            apply_low_priority_pool_size: std::cmp::max(1, cpu_num as usize),
         }
     }
 }
@@ -223,7 +224,10 @@ pub struct ImportConfig {
 
 impl Default for ImportConfig {
     fn default() -> ImportConfig {
-        ImportConfig { num_threads: 4 }
+        let cpu_num = SysQuota::cpu_cores_quota();
+        ImportConfig {
+            num_threads: std::cmp::min(256, (cpu_num * 8.0) as usize),
+        }
     }
 }
 

--- a/proxy_tests/proxy/config.rs
+++ b/proxy_tests/proxy/config.rs
@@ -117,7 +117,10 @@ fn test_config_proxy_default_no_config_item() {
         background_thread_count
     );
 
-    assert_eq!(config.import.num_threads, 4);
+    assert_eq!(
+        config.import.num_threads,
+        std::cmp::min(256, (cpu_num * 8.0) as usize)
+    );
     assert_eq!(config.server.status_thread_pool_size, 2);
 }
 


### PR DESCRIPTION
Cherry pick https://github.com/pingcap/tidb-engine-ext/pull/309

Note: the concurrency policy is different because import thread strategy is different in master.
