### PR TITLE
support fetch server_info without starting Proxy

### DIFF
--- a/proxy_components/proxy_ffi/src/interfaces.rs
+++ b/proxy_components/proxy_ffi/src/interfaces.rs
@@ -615,12 +615,12 @@ pub mod root {
         }
         extern "C" {
             pub fn ffi_server_info_noproxy(
-                server_helper: isize,
-                arg1: root::DB::BaseBuffView,
-                arg2: root::DB::RawVoidPtr,
+                arg1: isize,
+                arg2: root::DB::BaseBuffView,
+                arg3: root::DB::RawVoidPtr,
             ) -> u32;
         }
-        pub const RAFT_STORE_PROXY_VERSION: u64 = 13376970459625090056;
+        pub const RAFT_STORE_PROXY_VERSION: u64 = 12007835858373468057;
         pub const RAFT_STORE_PROXY_MAGIC_NUMBER: u32 = 324508639;
     }
 }

--- a/proxy_components/proxy_ffi/src/interfaces.rs
+++ b/proxy_components/proxy_ffi/src/interfaces.rs
@@ -613,7 +613,14 @@ pub mod root {
                 ) -> root::DB::FastAddPeerRes,
             >,
         }
-        pub const RAFT_STORE_PROXY_VERSION: u64 = 3617226644007633432;
+        extern "C" {
+            pub fn ffi_server_info_noproxy(
+                server_helper: isize,
+                arg1: root::DB::BaseBuffView,
+                arg2: root::DB::RawVoidPtr,
+            ) -> u32;
+        }
+        pub const RAFT_STORE_PROXY_VERSION: u64 = 13376970459625090056;
         pub const RAFT_STORE_PROXY_MAGIC_NUMBER: u32 = 324508639;
     }
 }

--- a/proxy_components/proxy_ffi/src/interfaces.rs
+++ b/proxy_components/proxy_ffi/src/interfaces.rs
@@ -614,13 +614,13 @@ pub mod root {
             >,
         }
         extern "C" {
-            pub fn ffi_server_info_noproxy(
+            pub fn ffi_get_server_info_from_proxy(
                 arg1: isize,
                 arg2: root::DB::BaseBuffView,
                 arg3: root::DB::RawVoidPtr,
             ) -> u32;
         }
-        pub const RAFT_STORE_PROXY_VERSION: u64 = 12007835858373468057;
+        pub const RAFT_STORE_PROXY_VERSION: u64 = 17823293661468169526;
         pub const RAFT_STORE_PROXY_MAGIC_NUMBER: u32 = 324508639;
     }
 }

--- a/proxy_components/proxy_server/src/util.rs
+++ b/proxy_components/proxy_server/src/util.rs
@@ -79,7 +79,7 @@ pub extern "C" fn ffi_server_info(
 }
 
 #[no_mangle]
-pub extern "C" fn ffi_server_info_noproxy(
+pub extern "C" fn ffi_get_server_info_from_proxy(
     server_helper_ptr: isize,
     view: BaseBuffView,
     res: RawVoidPtr,

--- a/proxy_components/proxy_server/src/util.rs
+++ b/proxy_components/proxy_server/src/util.rs
@@ -93,7 +93,6 @@ pub extern "C" fn ffi_server_info_noproxy(
     let resp = server_info_for_ffi(req);
     let buff = engine_store_ffi::ffi::ProtoMsgBaseBuff::new(&resp);
     unsafe {
-        let v = &mut *(res as *mut kvproto::diagnosticspb::ServerInfoResponse);
         let server_helper = &(*(server_helper_ptr
             as *const engine_store_ffi::ffi::interfaces_ffi::EngineStoreServerHelper));
         server_helper.set_pb_msg_by_bytes(

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
@@ -1,3 +1,3 @@
 #pragma once
 #include <cstdint>
-namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 13376970459625090056ull; }
+namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 12007835858373468057ull; }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
@@ -1,3 +1,3 @@
 #pragma once
 #include <cstdint>
-namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 3617226644007633432ull; }
+namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 13376970459625090056ull; }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
@@ -1,3 +1,3 @@
 #pragma once
 #include <cstdint>
-namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 12007835858373468057ull; }
+namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 17823293661468169526ull; }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
@@ -304,4 +304,15 @@ struct EngineStoreServerHelper {
   FastAddPeerRes (*fn_fast_add_peer)(EngineStoreServerWrap *,
                                      uint64_t region_id, uint64_t new_peer_id);
 };
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Basically same as ffi_server_info, but no need to setup ProxyHelper, only need to setup ServerHelper.
+// Used when proxy not start.
+uint32_t ffi_server_info_noproxy(intptr_t server_helper, BaseBuffView, RawVoidPtr);
+#ifdef __cplusplus
+}
+#endif
+
 }  // namespace DB

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
@@ -308,9 +308,9 @@ struct EngineStoreServerHelper {
 #ifdef __cplusplus
 extern "C" {
 #endif
-// Basically same as ffi_server_info, but no need to setup ProxyHelper, only need to setup ServerHelper.
-// Used when proxy not start.
-uint32_t ffi_server_info_noproxy(intptr_t server_helper, BaseBuffView, RawVoidPtr);
+// Basically same as ffi_server_info, but no need to setup ProxyHelper, only
+// need to setup ServerHelper. Used when proxy not start.
+uint32_t ffi_server_info_noproxy(intptr_t, BaseBuffView, RawVoidPtr);
 #ifdef __cplusplus
 }
 #endif

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
@@ -310,7 +310,7 @@ extern "C" {
 #endif
 // Basically same as ffi_server_info, but no need to setup ProxyHelper, only
 // need to setup ServerHelper. Used when proxy not start.
-uint32_t ffi_server_info_noproxy(intptr_t, BaseBuffView, RawVoidPtr);
+uint32_t ffi_get_server_info_from_proxy(intptr_t, BaseBuffView, RawVoidPtr);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: 
Related TiFlash issue: https://github.com/pingcap/tiflash/issues/7436 (check TiFlash Issue to for Problem Summary)
Related TiFlash PR: https://github.com/pingcap/tiflash/pull/7577
### What is changed and how it works?
Add `ffi_server_info_noproxy`, which is basically same as `ffi_server_info`. 
The difference is that: `ffi_server_info_noproxy` doesn't need to start proxy, so this function only need pointer of **EngineStoreServerHelper**, which will setup in TiFlash Server(which contains the real function to setup PB to tiflash server memory). And no need **RaftStoreProxyHelper**, which needs to start proxy(proxy_server::run_proxy).
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
