### PR TITLE
Remove the copied raft log if the FAP process timeout

### DIFF
--- a/proxy_components/engine_store_ffi/src/core/fast_add_peer.rs
+++ b/proxy_components/engine_store_ffi/src/core/fast_add_peer.rs
@@ -111,14 +111,14 @@ impl<T: Transport + 'static, ER: RaftEngine> ProxyForwarder<T, ER> {
                                     "do_fallback" => do_fallback,
                             );
                             if do_fallback {
-                                /// Safety
-                                /// MsgAppend can be handled only when we set
-                                /// inited_or_fallback to true,
-                                /// so deleting raft logs here brings no race.
+                                // Safety
+                                // MsgAppend can be handled only when we set
+                                // inited_or_fallback to true,
+                                // so deleting raft logs here brings no race.
                                 let mut wb = self.raft_engine.log_batch(2);
                                 let raft_state = kvproto::raft_serverpb::RaftLocalState::default();
-                                self.raft_engine.clean(region_id, 0, &raft_state, &mut wb);
-                                self.raft_engine.consume(&mut wb, true);
+                                let _ = self.raft_engine.clean(region_id, 0, &raft_state, &mut wb);
+                                let _ = self.raft_engine.consume(&mut wb, true);
                                 o.get_mut().inited_or_fallback.store(true, Ordering::SeqCst);
                                 is_first = false;
                                 early_skip = false;

--- a/proxy_components/engine_store_ffi/src/core/fast_add_peer.rs
+++ b/proxy_components/engine_store_ffi/src/core/fast_add_peer.rs
@@ -111,6 +111,10 @@ impl<T: Transport + 'static, ER: RaftEngine> ProxyForwarder<T, ER> {
                                     "do_fallback" => do_fallback,
                             );
                             if do_fallback {
+                                /// Safety
+                                /// MsgAppend can be handled only when we set
+                                /// inited_or_fallback to true,
+                                /// so deleting raft logs here brings no race.
                                 let mut wb = self.raft_engine.log_batch(2);
                                 let raft_state = kvproto::raft_serverpb::RaftLocalState::default();
                                 self.raft_engine.clean(region_id, 0, &raft_state, &mut wb);

--- a/proxy_components/engine_store_ffi/src/core/fast_add_peer.rs
+++ b/proxy_components/engine_store_ffi/src/core/fast_add_peer.rs
@@ -96,8 +96,8 @@ impl<T: Transport + 'static, ER: RaftEngine> ProxyForwarder<T, ER> {
                             let need_fallback = elapsed > fallback_millis;
                             // TODO If snapshot is sent, we need fallback but can't do fallback?
                             let do_fallback = need_fallback;
-                            info!("fast path: ongoing {}:{} {}, MsgAppend duplicated",
-                                self.store_id, region_id, new_peer_id;
+                            info!("fast path: ongoing {}:{} {}, MsgAppend duplicated{}",
+                                self.store_id, region_id, new_peer_id, if do_fallback { ", fallback to normal" } else {""};
                                     "to_peer_id" => msg.get_to_peer().get_id(),
                                     "from_peer_id" => msg.get_from_peer().get_id(),
                                     "region_id" => region_id,
@@ -111,6 +111,10 @@ impl<T: Transport + 'static, ER: RaftEngine> ProxyForwarder<T, ER> {
                                     "do_fallback" => do_fallback,
                             );
                             if do_fallback {
+                                let mut wb = self.raft_engine.log_batch(2);
+                                let raft_state = kvproto::raft_serverpb::RaftLocalState::default();
+                                self.raft_engine.clean(region_id, 0, &raft_state, &mut wb);
+                                self.raft_engine.consume(&mut wb, true);
                                 o.get_mut().inited_or_fallback.store(true, Ordering::SeqCst);
                                 is_first = false;
                                 early_skip = false;
@@ -201,14 +205,6 @@ impl<T: Transport + 'static, ER: RaftEngine> ProxyForwarder<T, ER> {
                         "is_first" => is_first,
                 );
             } else {
-                let mut ents = vec![];
-                let max_len = inner_msg.get_index();
-                // TODO If remove this, test_timeout_fallback may fail. Need investigate.
-                for i in 0..max_len {
-                    if let Ok(Some(e)) = self.raft_engine.get_entry(region_id, i) {
-                        ents.push(e);
-                    }
-                }
                 info!("fast path: ongoing {}:{} {}, MsgAppend accepted",
                     self.store_id, region_id, new_peer_id;
                         "to_peer_id" => msg.get_to_peer().get_id(),
@@ -218,7 +214,6 @@ impl<T: Transport + 'static, ER: RaftEngine> ProxyForwarder<T, ER> {
                         "is_replicated" => is_replicated,
                         "has_already_inited" => has_already_inited,
                         "is_first" => is_first,
-                        "all_entries" => ?ents,
                 );
             }
         }

--- a/proxy_scripts/ci_check.sh
+++ b/proxy_scripts/ci_check.sh
@@ -55,8 +55,7 @@ elif [[ $M == "testnew" ]]; then
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy v1_specific::region_ext
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy v1_specific::flashback
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy shared::server_cluster_test -- --test-threads 1
-    # TODO test_timeout_fallback may fail with raft-engine. Need investigate.
-    cargo test --package proxy_tests --features="test-engine-kv-rocksdb test-engine-raft-rocksdb" --test proxy shared::fast_add_peer
+    cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy shared::fast_add_peer
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy shared::replica_read -- --test-threads 1
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy shared::ffi -- --test-threads 1
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy shared::write --features="proxy_tests/enable-pagestorage"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

In FAP, the region is not initialized before the fake snapshot is applied. So the meta states should be nothing, and the raft log should be empty.

When applying a snapshot, we will delete all raft log, meta states only if the peer is initialized.

However, before we sent snapshot, we will copy some raft log entries. However, if the FAP process timeout, and fallback into a normal snapshot from Leader, then these logs will NOT be deleted because the peer is not initialized.

If we use raft-engine, this may lead to a hold in raft log, and panic.
Otherwise, this may still lead to leaking.

See [CalvinNeo:debug/raft-engine-mem-hole](https://github.com/CalvinNeo/tidb-engine-ext/tree/debug/raft-engine-mem-hole)

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
