### PR TITLE
Support arena.i.purge when jemalloc is used

### DIFF
--- a/components/engine_panic/Cargo.toml
+++ b/components/engine_panic/Cargo.toml
@@ -10,9 +10,9 @@ license = "Apache-2.0"
 testexport = []
 
 [dependencies]
+encryption = { workspace = true }
 engine_traits = { workspace = true }
 kvproto = { workspace = true }
-encryption = { workspace = true }
 raft = { workspace = true }
 tracker = { workspace = true }
 txn_types = { workspace = true }

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -61,6 +61,6 @@ package = "rocksdb"
 features = ["encryption"]
 
 [dev-dependencies]
+proptest = "1.0.0"
 rand = "0.8"
 toml = "0.5"
-proptest = "1.0.0"

--- a/components/engine_traits/Cargo.toml
+++ b/components/engine_traits/Cargo.toml
@@ -11,6 +11,7 @@ testexport = []
 
 [dependencies]
 collections = { workspace = true }
+encryption = { workspace = true }
 error_code = { workspace = true }
 fail = "0.5"
 file_system = { workspace = true }
@@ -19,7 +20,6 @@ kvproto = { workspace = true }
 log_wrappers = { workspace = true }
 protobuf = "2"
 raft = { workspace = true }
-encryption = { workspace = true }
 serde = "1.0"
 slog = { workspace = true }
 slog-global = { workspace = true }

--- a/components/hybrid_engine/Cargo.toml
+++ b/components/hybrid_engine/Cargo.toml
@@ -6,27 +6,27 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-engine_traits = { workspace = true }
-txn_types = { workspace = true }
-tikv_util = { workspace = true }
+crossbeam = { workspace = true }
 engine_rocks = { workspace = true }
-online_config = { workspace = true }
+engine_traits = { workspace = true }
 in_memory_engine = { workspace = true }
-slog = { workspace = true }
-slog-global = { workspace = true }
-tempfile = "3.0"
+keys = { workspace = true }
+kvproto = { workspace = true }
+lazy_static = "1.4.0"
+online_config = { workspace = true }
 prometheus = { version = "0.13", default-features = false, features = [
     "nightly",
 ] }
 prometheus-static-metric = "0.5"
-lazy_static = "1.4.0"
-crossbeam = { workspace = true }
-raftstore = { workspace = true }
 raft = { workspace = true }
-kvproto = { workspace = true }
-keys = { workspace = true }
+raftstore = { workspace = true }
+slog = { workspace = true }
+slog-global = { workspace = true }
+tempfile = "3.0"
+tikv_util = { workspace = true }
+txn_types = { workspace = true }
 
 [dev-dependencies]
+fail = { version = "0.5", features = ["failpoints"] }
 tempfile = "3.0"
 test_util = { workspace = true }
-fail = { version = "0.5", features = ["failpoints"] }

--- a/components/in_memory_engine/Cargo.toml
+++ b/components/in_memory_engine/Cargo.toml
@@ -20,44 +20,44 @@ path = "benches/load_region.rs"
 harness = false
 
 [dependencies]
-engine_traits = { workspace = true }
-collections = { workspace = true }
-crossbeam-skiplist = { workspace = true }
 bytes = "1.0"
+collections = { workspace = true }
 crossbeam = { workspace = true }
-futures = { version = "0.3", features = ["compat"] }
-tikv_util = { workspace = true }
-txn_types = { workspace = true }
-kvproto = { workspace = true }
-log_wrappers = { workspace = true }
-pd_client = { workspace = true }
-raftstore = { workspace = true }
+crossbeam-skiplist = { workspace = true }
 dashmap = "5.1"
+engine_rocks = { workspace = true }
+engine_traits = { workspace = true }
+fail = "0.5"
+futures = { version = "0.3", features = ["compat"] }
+hex = "0.4"
+keys = { workspace = true }
+kvproto = { workspace = true }
+lazy_static = "1.4.0"
+libc = "0.2"
+log_wrappers = { workspace = true }
+online_config = { workspace = true }
+parking_lot = "0.12"
+pd_client = { workspace = true }
+prometheus = { version = "0.13", default-features = false, features = ["nightly"] }
+prometheus-static-metric = "0.5"
+raftstore = { workspace = true }
+rand = "0.8"
 security = { workspace = true }
 serde = "1.0"
 serde_json = "1.0"
-slog-global = { workspace = true }
 slog = { workspace = true }
-strum = { version = "0.20", features = ["derive"] }
-engine_rocks = { workspace = true }
-fail = "0.5"
-yatp = { workspace = true }
-parking_lot = "0.12"
-keys = { workspace = true }
-prometheus = { version = "0.13", default-features = false, features = ["nightly"] }
-prometheus-static-metric = "0.5"
-lazy_static = "1.4.0"
-hex = "0.4"
-thiserror = "1.0"
-online_config = { workspace = true }
-libc = "0.2"
-rand = "0.8"
-tokio = { version = "1.5", features = ["rt-multi-thread"] }
+slog-global = { workspace = true }
 smallvec = "1.4"
+strum = { version = "0.20", features = ["derive"] }
+thiserror = "1.0"
+tikv_util = { workspace = true }
+tokio = { version = "1.5", features = ["rt-multi-thread"] }
+txn_types = { workspace = true }
+yatp = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.3"
+proptest = "1.0.0"
 tempfile = "3.0"
 test_pd = { workspace = true }
 test_util = { workspace = true }
-proptest = "1.0.0"

--- a/components/raft_log_engine/Cargo.toml
+++ b/components/raft_log_engine/Cargo.toml
@@ -9,9 +9,9 @@ license = "Apache-2.0"
 failpoints = ["raft-engine/failpoints"]
 
 [dependencies]
+codec = { workspace = true }
 encryption = { workspace = true }
 engine_traits = { workspace = true }
-codec = { workspace = true }
 file_system = { workspace = true }
 kvproto = { workspace = true }
 raft = { workspace = true }

--- a/proxy_components/proxy_ffi/src/jemalloc_utils.rs
+++ b/proxy_components/proxy_ffi/src/jemalloc_utils.rs
@@ -117,9 +117,7 @@ pub fn get_deallocate() -> u64 {
     issue_mallctl("thread.deallocated")
 }
 
-use std::{
-    ffi::{c_char, c_void, CStr},
-};
+use std::ffi::{c_char, c_void, CStr};
 struct CaptureContext {
     buffer: Mutex<String>,
 }

--- a/proxy_components/proxy_ffi/src/jemalloc_utils.rs
+++ b/proxy_components/proxy_ffi/src/jemalloc_utils.rs
@@ -145,6 +145,10 @@ pub fn get_malloc_stats() -> String {
         buffer: Mutex::new(String::new()),
     };
 
+    // Use Json format.
+    let c_str = std::ffi::CString::new("J").unwrap();
+    let ops_str = c_str.as_ptr() as *const std::os::raw::c_char;
+
     unsafe {
         // See unprefixed_malloc_on_supported_platforms in tikv-jemalloc-sys.
         #[cfg(any(test, feature = "testexport"))]
@@ -157,7 +161,7 @@ pub fn get_malloc_stats() -> String {
                 _rjem_malloc_stats_print(
                     Some(write_to_string),
                     &context as *const _ as *mut c_void,
-                    std::ptr::null(),
+                    ops_str,
                 );
                 #[cfg(not(any(
                     target_os = "android",
@@ -167,7 +171,7 @@ pub fn get_malloc_stats() -> String {
                 malloc_stats_print(
                     Some(write_to_string),
                     &context as *const _ as *mut c_void,
-                    std::ptr::null(),
+                    ops_str,
                 );
             }
         }
@@ -181,7 +185,7 @@ pub fn get_malloc_stats() -> String {
                 malloc_stats_print(
                     Some(write_to_string),
                     &context as *const _ as *mut c_void,
-                    std::ptr::null(),
+                    ops_str,
                 );
             }
             #[cfg(not(feature = "external-jemalloc"))]
@@ -196,7 +200,7 @@ pub fn get_malloc_stats() -> String {
                     malloc_stats_print(
                         Some(write_to_string),
                         &context as *const _ as *mut c_void,
-                        std::ptr::null(),
+                        ops_str,
                     );
                 }
             }

--- a/proxy_components/proxy_ffi/src/jemalloc_utils.rs
+++ b/proxy_components/proxy_ffi/src/jemalloc_utils.rs
@@ -119,12 +119,12 @@ pub fn get_deallocate() -> u64 {
 
 use std::{
     ffi::{c_char, c_void, CStr},
-    ptr,
 };
 struct CaptureContext {
     buffer: Mutex<String>,
 }
 
+#[allow(dead_code)]
 extern "C" fn write_to_string(ctx: *mut c_void, message: *const c_char) {
     if ctx.is_null() || message.is_null() {
         return;
@@ -139,6 +139,9 @@ extern "C" fn write_to_string(ctx: *mut c_void, message: *const c_char) {
     }
 }
 
+#[allow(unused_variables)]
+#[allow(unused_mut)]
+#[allow(unused_unsafe)]
 pub fn get_malloc_stats() -> String {
     let context = CaptureContext {
         buffer: Mutex::new(String::new()),
@@ -156,7 +159,7 @@ pub fn get_malloc_stats() -> String {
                 _rjem_malloc_stats_print(
                     Some(write_to_string),
                     &context as *const _ as *mut c_void,
-                    ptr::null(),
+                    std::ptr::null(),
                 );
                 #[cfg(not(any(
                     target_os = "android",
@@ -166,7 +169,7 @@ pub fn get_malloc_stats() -> String {
                 malloc_stats_print(
                     Some(write_to_string),
                     &context as *const _ as *mut c_void,
-                    ptr::null(),
+                    std::ptr::null(),
                 );
             }
         }
@@ -180,7 +183,7 @@ pub fn get_malloc_stats() -> String {
                 malloc_stats_print(
                     Some(write_to_string),
                     &context as *const _ as *mut c_void,
-                    ptr::null(),
+                    std::ptr::null(),
                 );
             }
             #[cfg(not(feature = "external-jemalloc"))]
@@ -195,7 +198,7 @@ pub fn get_malloc_stats() -> String {
                     malloc_stats_print(
                         Some(write_to_string),
                         &context as *const _ as *mut c_void,
-                        ptr::null(),
+                        std::ptr::null(),
                     );
                 }
             }

--- a/proxy_components/proxy_ffi/src/jemalloc_utils.rs
+++ b/proxy_components/proxy_ffi/src/jemalloc_utils.rs
@@ -1,4 +1,5 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+use std::sync::Mutex;
 
 extern "C" {
     // External jemalloc
@@ -18,6 +19,12 @@ extern "C" {
         newp: *mut ::std::os::raw::c_void,
         newlen: u64,
     ) -> ::std::os::raw::c_int;
+
+    pub fn malloc_stats_print(
+        write_cb: Option<unsafe extern "C" fn(*mut c_void, *const i8)>,
+        cbopaque: *mut c_void,
+        opts: *const i8,
+    );
 }
 
 #[allow(unused_variables)]
@@ -108,4 +115,93 @@ pub fn get_allocate() -> u64 {
 
 pub fn get_deallocate() -> u64 {
     issue_mallctl("thread.deallocated")
+}
+
+use std::{
+    ffi::{c_char, c_void, CStr},
+    ptr,
+};
+struct CaptureContext {
+    buffer: Mutex<String>,
+}
+
+extern "C" fn write_to_string(ctx: *mut c_void, message: *const c_char) {
+    if ctx.is_null() || message.is_null() {
+        return;
+    }
+
+    let context = unsafe { &*(ctx as *mut CaptureContext) };
+
+    let c_str = unsafe { CStr::from_ptr(message) };
+    if let Ok(str_slice) = c_str.to_str() {
+        let mut buffer = context.buffer.lock().unwrap();
+        buffer.push_str(str_slice);
+    }
+}
+
+pub fn get_malloc_stats() -> String {
+    let context = CaptureContext {
+        buffer: Mutex::new(String::new()),
+    };
+
+    unsafe {
+        // See unprefixed_malloc_on_supported_platforms in tikv-jemalloc-sys.
+        #[cfg(any(test, feature = "testexport"))]
+        {
+            // Test part
+            #[cfg(feature = "jemalloc")]
+            {
+                // See NO_UNPREFIXED_MALLOC
+                #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "macos"))]
+                _rjem_malloc_stats_print(
+                    Some(write_to_string),
+                    &context as *const _ as *mut c_void,
+                    ptr::null(),
+                );
+                #[cfg(not(any(
+                    target_os = "android",
+                    target_os = "dragonfly",
+                    target_os = "macos"
+                )))]
+                malloc_stats_print(
+                    Some(write_to_string),
+                    &context as *const _ as *mut c_void,
+                    ptr::null(),
+                );
+            }
+        }
+
+        #[cfg(not(any(test, feature = "testexport")))]
+        {
+            // No test part
+            #[cfg(feature = "external-jemalloc")]
+            {
+                // Must linked to tiflash.
+                malloc_stats_print(
+                    Some(write_to_string),
+                    &context as *const _ as *mut c_void,
+                    ptr::null(),
+                );
+            }
+            #[cfg(not(feature = "external-jemalloc"))]
+            {
+                // Happens only with `raftstore-proxy-main`
+                #[cfg(not(any(
+                    target_os = "android",
+                    target_os = "dragonfly",
+                    target_os = "macos"
+                )))]
+                {
+                    malloc_stats_print(
+                        Some(write_to_string),
+                        &context as *const _ as *mut c_void,
+                        ptr::null(),
+                    );
+                }
+            }
+        }
+    }
+
+    let buffer = context.buffer.lock().unwrap();
+    buffer.clone()
 }

--- a/proxy_components/proxy_ffi/src/jemalloc_utils.rs
+++ b/proxy_components/proxy_ffi/src/jemalloc_utils.rs
@@ -80,7 +80,7 @@ pub fn issue_mallctl_args(
 #[allow(unused_variables)]
 #[allow(unused_mut)]
 #[allow(unused_unsafe)]
-fn issue_mallctl(command: &str) -> u64 {
+pub fn issue_mallctl(command: &str) -> u64 {
     type PtrUnderlying = u64;
     let mut ptr: PtrUnderlying = 0;
     let mut size = std::mem::size_of::<PtrUnderlying>() as u64;

--- a/proxy_components/proxy_server/src/status_server/mod.rs
+++ b/proxy_components/proxy_server/src/status_server/mod.rs
@@ -63,7 +63,7 @@ use tokio::{
     sync::oneshot::{self, Receiver, Sender},
 };
 use tokio_openssl::SslStream;
-use vendored_utils::jeprof_purge_arena;
+use vendored_utils::{jeprof_memory_status, jeprof_purge_arena};
 
 use crate::status_server::profile::set_prof_active;
 
@@ -247,6 +247,11 @@ where
     async fn arena_purge(_: Request<Body>) -> hyper::Result<Response<Body>> {
         jeprof_purge_arena();
         Ok(make_response(StatusCode::OK, "purge OK"))
+    }
+
+    async fn memory_status(_: Request<Body>) -> hyper::Result<Response<Body>> {
+        let s = jeprof_memory_status();
+        Ok(make_response(StatusCode::OK, s))
     }
 
     #[allow(dead_code)]
@@ -804,6 +809,9 @@ where
                             }
                             (Method::GET, "/debug/pprof/arena_purge") => {
                                 Self::arena_purge(req).await
+                            }
+                            (Method::GET, "/debug/pprof/memory_status") => {
+                                Self::memory_status(req).await
                             }
                             (Method::GET, "/config") => {
                                 Self::get_config(req, &cfg_controller, engine_store_server_helper)

--- a/proxy_components/proxy_server/src/status_server/mod.rs
+++ b/proxy_components/proxy_server/src/status_server/mod.rs
@@ -63,6 +63,7 @@ use tokio::{
     sync::oneshot::{self, Receiver, Sender},
 };
 use tokio_openssl::SslStream;
+use vendored_utils::jeprof_purge_arena;
 
 use crate::status_server::profile::set_prof_active;
 
@@ -241,6 +242,11 @@ where
             Ok(()) => Ok(make_response(StatusCode::OK, "set prof.active succeed")),
             Err(err) => Ok(make_response(StatusCode::BAD_REQUEST, err.to_string())),
         }
+    }
+
+    async fn arena_purge(_: Request<Body>) -> hyper::Result<Response<Body>> {
+        jeprof_purge_arena();
+        Ok(make_response(StatusCode::OK, "purge OK"))
     }
 
     #[allow(dead_code)]
@@ -795,6 +801,9 @@ where
                             }
                             (Method::GET, "/debug/pprof/heap") => {
                                 Self::dump_heap_prof_to_resp(req).await
+                            }
+                            (Method::GET, "/debug/pprof/arena_purge") => {
+                                Self::arena_purge(req).await
                             }
                             (Method::GET, "/config") => {
                                 Self::get_config(req, &cfg_controller, engine_store_server_helper)

--- a/proxy_components/proxy_server/src/status_server/vendored_utils.rs
+++ b/proxy_components/proxy_server/src/status_server/vendored_utils.rs
@@ -128,5 +128,5 @@ pub fn jeprof_purge_arena() {
 }
 
 pub fn jeprof_memory_status() -> String {
-    return get_malloc_stats();
+    get_malloc_stats()
 }

--- a/proxy_components/proxy_server/src/status_server/vendored_utils.rs
+++ b/proxy_components/proxy_server/src/status_server/vendored_utils.rs
@@ -121,7 +121,7 @@ pub fn jeprof_purge_arena() {
             0,
         );
         if r != 0 {
-            info!("jeprof_purge_arena purge {} return {}", a_string, r);
+            warn!("jeprof_purge_arena purge {} return {}", a_string, r);
         }
     }
 }

--- a/proxy_components/proxy_server/src/status_server/vendored_utils.rs
+++ b/proxy_components/proxy_server/src/status_server/vendored_utils.rs
@@ -124,5 +124,5 @@ pub fn jeprof_purge_arena() {
             warn!("jeprof_purge_arena purge {} return {}", a_string, r);
         }
     }
-        info!("jeprof_purge_arena purge {} arenas done", narenas);
+    info!("jeprof_purge_arena purge {} arenas done", narenas);
 }

--- a/proxy_components/proxy_server/src/status_server/vendored_utils.rs
+++ b/proxy_components/proxy_server/src/status_server/vendored_utils.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use proxy_ffi::jemalloc_utils::{issue_mallctl, issue_mallctl_args};
+use proxy_ffi::jemalloc_utils::{get_malloc_stats, issue_mallctl, issue_mallctl_args};
 use tikv_alloc::error::ProfResult;
 
 pub fn activate_prof() -> ProfResult<()> {
@@ -125,4 +125,8 @@ pub fn jeprof_purge_arena() {
         }
     }
     info!("jeprof_purge_arena purge {} arenas done", narenas);
+}
+
+pub fn jeprof_memory_status() -> String {
+    return get_malloc_stats();
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

- Provide an http interface "/debug/pprof/arena_purge" for purging the dirty/muzzy page in jemalloc. This could help reduce the memory consumption after large txn is committed.
    Reference: https://jemalloc.net/jemalloc.3.html#opt.muzzy_decay_ms
- Provide an http interface "/debug/pprof/memory_status" to get memory allocation information is using jemalloc. Note that the return result may take dozens MiB.

![image](https://github.com/user-attachments/assets/6eaaad1f-5aa5-4e7f-b81d-aa9f0e01de81)

![image](https://github.com/user-attachments/assets/00999914-7447-4f4a-a512-d420818636ca)


### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
