### PR TITLE
CP: Fix ps_engine.raftlog unset under default raft-engine dir (#404) to release-8.1

### DIFF
--- a/proxy_components/proxy_server/src/run.rs
+++ b/proxy_components/proxy_server/src/run.rs
@@ -631,10 +631,15 @@ impl<ER: RaftEngine, F: KvFormat> TiKvServer<ER, F> {
 
         // NOTE: Compat disagg arch upgraded from * to 8.0.
         {
-            let raft_engine_path = config.raft_engine.config().dir + "/ps_engine";
+            let engine_dir = config.raft_engine.config().dir.clone();
+            let infered_dir = config
+                .infer_raft_engine_path(None)
+                .unwrap_or(engine_dir.clone());
+            info!("raft_engine_dir"; "origin" => engine_dir, "infered" => infered_dir.clone());
+            let raft_engine_path = infered_dir.clone() + "/ps_engine";
             let path = Path::new(&raft_engine_path);
             if path.exists() {
-                let new_raft_engine_path = config.raft_engine.config().dir + "/ps_engine.raftlog";
+                let new_raft_engine_path = infered_dir + "/ps_engine.raftlog";
                 let new_path = Path::new(&new_raft_engine_path);
                 if !new_path.exists() {
                     info!("creating ps_engine.raftlog for upgraded cluster");

--- a/proxy_scripts/ci_check.sh
+++ b/proxy_scripts/ci_check.sh
@@ -61,7 +61,7 @@ elif [[ $M == "testnew" ]]; then
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy shared::flashback
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy v2_compat::cluster_raftstore_ver
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy v2_compat::tablet_snapshot
-    cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy v2_compat::simple_write
+    # cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy v2_compat::simple_write
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy v1_specific::region_ext
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy v1_specific::flashback
     cargo test --package proxy_tests --features="$ENABLE_FEATURES" --test proxy shared::server_cluster_test -- --test-threads 1


### PR DESCRIPTION
cherry-pick of https://github.com/pingcap/tidb-engine-ext/pull/404
* * *
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx


<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
