### PR TITLE
Fix arm build of malloc_stats_print

### DIFF
--- a/proxy_components/proxy_ffi/src/jemalloc_utils.rs
+++ b/proxy_components/proxy_ffi/src/jemalloc_utils.rs
@@ -21,9 +21,9 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 
     pub fn malloc_stats_print(
-        write_cb: Option<unsafe extern "C" fn(*mut c_void, *const c_char)>,
+        write_cb: Option<unsafe extern "C" fn(*mut c_void, *const ::std::os::raw::c_char)>,
         cbopaque: *mut c_void,
-        opts: *const c_char,
+        opts: *const ::std::os::raw::c_char,
     );
 }
 

--- a/proxy_components/proxy_ffi/src/jemalloc_utils.rs
+++ b/proxy_components/proxy_ffi/src/jemalloc_utils.rs
@@ -21,9 +21,9 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 
     pub fn malloc_stats_print(
-        write_cb: Option<unsafe extern "C" fn(*mut c_void, *const i8)>,
+        write_cb: Option<unsafe extern "C" fn(*mut c_void, *const c_char)>,
         cbopaque: *mut c_void,
-        opts: *const i8,
+        opts: *const c_char,
     );
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

There is a error on arm build
```
error[E0308]: mismatched types
   --> proxy_components/proxy_ffi/src/jemalloc_utils.rs:186:26
    |
186 |                     Some(write_to_string),
    |                     ---- ^^^^^^^^^^^^^^^ expected fn pointer, found fn item
    |                     |
    |                     arguments to this enum variant are incorrect
    |
    = note: expected fn pointer `unsafe extern "C" fn(_, *const i8)`
                  found fn item `extern "C" fn(_, *const u8) {write_to_string}`
help: the type constructed contains `extern "C" fn(*mut c_void, *const u8) {write_to_string}` due to the type of the argument passed
   --> proxy_components/proxy_ffi/src/jemalloc_utils.rs:186:21
    |
186 |                     Some(write_to_string),
    |                     ^^^^^---------------^
    |                          |
    |                          this argument influences the type of `Some`
note: tuple variant defined here
   --> /root/.rustup/toolchains/nightly-2023-12-28-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:578:5
    |
578 |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     ^^^^

error[E0308]: mismatched types
   --> proxy_components/proxy_ffi/src/jemalloc_utils.rs:188:21
    |
185 |                 malloc_stats_print(
    |                 ------------------ arguments to this function are incorrect
...
188 |                     ops_str,
    |                     ^^^^^^^ expected `*const i8`, found `*const u8`
    |
    = note: expected raw pointer `*const i8`
               found raw pointer `*const u8`
note: function defined here
   --> proxy_components/proxy_ffi/src/jemalloc_utils.rs:23:12
    |
23  |     pub fn malloc_stats_print(
    |            ^^^^^^^^^^^^^^^^^^
```

The fix is to use c_char instead of u8 or i8.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
