### PR TITLE
Specify extra store labels by param `--labels`

### DIFF
--- a/proxy_components/proxy_server/src/proxy.rs
+++ b/proxy_components/proxy_server/src/proxy.rs
@@ -270,14 +270,6 @@ pub unsafe fn run_proxy(
                 .required(true)
                 .takes_value(true),
         )
-        /* 
-        .arg(
-            Arg::with_name("engine-role-label")
-                .long("engine-role-label")
-                .help("Set engine role label")
-                .takes_value(true),
-        )
-        */
         .arg(
             Arg::with_name("only-decryption")
                 .long("only-decryption")

--- a/proxy_components/proxy_server/src/proxy.rs
+++ b/proxy_components/proxy_server/src/proxy.rs
@@ -202,22 +202,6 @@ pub unsafe fn run_proxy(
                 .long_help("Set the PD endpoints to use. Use `,` to separate multiple PDs"),
         )
         .arg(
-            Arg::with_name("labels")
-                .long("labels")
-                .alias("label")
-                .takes_value(true)
-                .value_name("KEY=VALUE")
-                .multiple(true)
-                .use_delimiter(true)
-                .require_delimiter(true)
-                .value_delimiter(",")
-                .help("Sets server labels")
-                .long_help(
-                    "Set the server labels. Uses `,` to separate kv pairs, like \
-                     `zone=cn,disk=ssd`",
-                ),
-        )
-        .arg(
             Arg::with_name("print-sample-config")
                 .long("print-sample-config")
                 .help("Print a sample config to stdout"),
@@ -264,22 +248,40 @@ pub unsafe fn run_proxy(
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("labels")
+                .long("labels")
+                .alias("label")
+                .takes_value(true)
+                .value_name("KEY=VALUE")
+                .multiple(true)
+                .use_delimiter(true)
+                .require_delimiter(true)
+                .value_delimiter(",")
+                .help("Sets server labels")
+                .long_help(
+                    "Set the server labels. Uses `,` to separate kv pairs, like \
+                     `zone=cn,disk=ssd`",
+                ),
+        )
+        .arg(
             Arg::with_name("engine-label")
                 .long("engine-label")
                 .help("Set engine label")
                 .required(true)
                 .takes_value(true),
         )
-        .arg(
-            Arg::with_name("only-decryption")
-                .long("only-decryption")
-                .help("Only do decryption in Proxy"),
-        )
+        /* 
         .arg(
             Arg::with_name("engine-role-label")
                 .long("engine-role-label")
                 .help("Set engine role label")
                 .takes_value(true),
+        )
+        */
+        .arg(
+            Arg::with_name("only-decryption")
+                .long("only-decryption")
+                .help("Only do decryption in Proxy"),
         )
         .arg(
             Arg::with_name("memory-limit-size")

--- a/proxy_components/proxy_server/src/setup.rs
+++ b/proxy_components/proxy_server/src/setup.rs
@@ -120,7 +120,8 @@ pub fn overwrite_config_with_cmd_args(
             }
             labels.insert(key, value);
         }
-        config.server.labels = labels;
+        // append the labels to `config.server.labels`
+        config.server.labels.extend(labels);
     }
 
     if let Some(capacity_str) = matches.value_of("capacity") {
@@ -148,13 +149,13 @@ pub fn overwrite_config_with_cmd_args(
                 .unwrap(),
         ),
     );
-    const DEFAULT_ENGINE_ROLE_LABEL_KEY: &str = "engine_role";
-    if let Some(engine_role_value) = matches.value_of("engine-role-label") {
-        config.server.labels.insert(
-            DEFAULT_ENGINE_ROLE_LABEL_KEY.to_owned(),
-            String::from(engine_role_value),
-        );
-    }
+    // const DEFAULT_ENGINE_ROLE_LABEL_KEY: &str = "engine_role";
+    // if let Some(engine_role_value) = matches.value_of("engine-role-label") {
+    // config.server.labels.insert(
+    // DEFAULT_ENGINE_ROLE_LABEL_KEY.to_owned(),
+    // String::from(engine_role_value),
+    // );
+    // }
     if let Some(unips_enabled_str) = matches.value_of("unips-enabled") {
         let enabled: u64 = unips_enabled_str.parse().unwrap_or_else(|e| {
             fatal!("invalid unips-enabled: {}", e);

--- a/proxy_components/proxy_server/src/setup.rs
+++ b/proxy_components/proxy_server/src/setup.rs
@@ -149,13 +149,6 @@ pub fn overwrite_config_with_cmd_args(
                 .unwrap(),
         ),
     );
-    // const DEFAULT_ENGINE_ROLE_LABEL_KEY: &str = "engine_role";
-    // if let Some(engine_role_value) = matches.value_of("engine-role-label") {
-    // config.server.labels.insert(
-    // DEFAULT_ENGINE_ROLE_LABEL_KEY.to_owned(),
-    // String::from(engine_role_value),
-    // );
-    // }
     if let Some(unips_enabled_str) = matches.value_of("unips-enabled") {
         let enabled: u64 = unips_enabled_str.parse().unwrap_or_else(|e| {
             fatal!("invalid unips-enabled: {}", e);

--- a/proxy_components/proxy_server/src/setup.rs
+++ b/proxy_components/proxy_server/src/setup.rs
@@ -2,7 +2,6 @@
 use std::borrow::ToOwned;
 
 use clap::ArgMatches;
-use collections::HashMap;
 pub use server::setup::initial_logger;
 use tikv::config::{MetricConfig, TikvConfig, MEMORY_USAGE_LIMIT_RATE};
 use tikv_util::{self, config::ReadableSize, logger, sys::SysQuota};
@@ -107,7 +106,7 @@ pub fn overwrite_config_with_cmd_args(
     }
 
     if let Some(labels_vec) = matches.values_of("labels") {
-        let mut labels = HashMap::default();
+        // labels_vec is a vector of string like ["k1=v1", "k1=v2", ...]
         for label in labels_vec {
             let mut parts = label.split('=');
             let key = parts.next().unwrap().to_owned();
@@ -118,23 +117,18 @@ pub fn overwrite_config_with_cmd_args(
             if parts.next().is_some() {
                 fatal!("invalid label: {}", label);
             }
-            labels.insert(key, value);
+            if config.server.labels.contains_key(&key) {
+                warn!(
+                    "label is ignored due to duplicated key defined in `server.labels`, key={} value={}",
+                    key, value
+                );
+                continue; // ignore duplicated label
+            }
+            // only set the label when `server.labels` does not contain the label with the
+            // same key
+            config.server.labels.insert(key, value);
         }
-        // append the labels to `config.server.labels`
-        config.server.labels.extend(labels);
     }
-
-    if let Some(capacity_str) = matches.value_of("capacity") {
-        let capacity = capacity_str.parse().unwrap_or_else(|e| {
-            fatal!("invalid capacity: {}", e);
-        });
-        config.raft_store.capacity = capacity;
-    }
-
-    if matches.value_of("metrics-addr").is_some() {
-        warn!("metrics push is not supported any more.");
-    }
-
     // User can specify engine label, because we need to distinguish TiFlash role
     // (tiflash-compute or tiflash-storage) in the disaggregated architecture.
     // If no engine label is specified, we use 'ENGINE_LABEL_VALUE'(env variable
@@ -149,6 +143,18 @@ pub fn overwrite_config_with_cmd_args(
                 .unwrap(),
         ),
     );
+
+    if let Some(capacity_str) = matches.value_of("capacity") {
+        let capacity = capacity_str.parse().unwrap_or_else(|e| {
+            fatal!("invalid capacity: {}", e);
+        });
+        config.raft_store.capacity = capacity;
+    }
+
+    if matches.value_of("metrics-addr").is_some() {
+        warn!("metrics push is not supported any more.");
+    }
+
     if let Some(unips_enabled_str) = matches.value_of("unips-enabled") {
         let enabled: u64 = unips_enabled_str.parse().unwrap_or_else(|e| {
             fatal!("invalid unips-enabled: {}", e);

--- a/proxy_tests/proxy/shared/config.rs
+++ b/proxy_tests/proxy/shared/config.rs
@@ -283,7 +283,7 @@ fn test_config_proxy_engine_role_label() {
 
 // We test whether Proxy will overwrite TiKV's value,
 // when a config item which is both defined by ProxyConfig and TikvConfig.
-// We only nned to add tests to this function when the logic is different.
+// We only need to add tests to this function when the logic is different.
 #[test]
 fn test_overwrite() {
     let mut file = tempfile::NamedTempFile::new().unwrap();
@@ -476,5 +476,167 @@ memory-usage-limit = 42
         let mut config = bootstrap2(args);
         assert!(config.validate().is_ok());
         assert_eq!(config.memory_usage_limit, Some(ReadableSize(42)));
+    }
+}
+
+#[test]
+fn test_label_overwrite() {
+    let app = App::new("RaftStore Proxy")
+        .arg(
+            Arg::with_name("labels")
+                .long("labels")
+                .alias("label")
+                .takes_value(true)
+                .value_name("KEY=VALUE")
+                .multiple(true)
+                .use_delimiter(true)
+                .require_delimiter(true)
+                .value_delimiter(",")
+                .help("Sets server labels")
+                .long_help(
+                    "Set the server labels. Uses `,` to separate kv pairs, like \
+                `zone=cn,disk=ssd`",
+                ),
+        )
+        .arg(
+            Arg::with_name("engine-label")
+                .long("engine-label")
+                .help("Set engine label")
+                .required(true)
+                .takes_value(true),
+        );
+
+    let get_config = |args: Vec<&str>, labels: Option<&str>| {
+        let mut v: Vec<String> = vec![];
+        // args
+        let matches = app.clone().get_matches_from(args);
+        // Gen tiflash_tikv.toml
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            file,
+            "
+[server]
+[server.labels]
+{}
+            ",
+            labels.unwrap_or_default()
+        )
+        .unwrap();
+        let cpath = Some(file.path().as_os_str());
+        let mut config = gen_tikv_config(&cpath, false, &mut v);
+        let mut proxy_config = gen_proxy_config(&cpath, false, &mut v);
+        overwrite_config_with_cmd_args(&mut config, &mut proxy_config, &matches);
+        address_proxy_config(&mut config, &proxy_config);
+        config.compatible_adjust();
+        config
+    };
+
+    {
+        let args = vec!["test_label", "--engine-label", "tiflash"];
+        let mut config = get_config(args, None);
+        assert!(config.validate().is_ok());
+        let expected_labels = [("engine".to_owned(), "tiflash".to_owned())]
+            .iter()
+            .cloned()
+            .collect();
+        assert!(config.server.labels == expected_labels);
+    }
+    {
+        let args = vec!["test_label", "--engine-label", "tiflash_compute"];
+        let mut config = get_config(args, None);
+        assert!(config.validate().is_ok());
+        let expected_labels = [("engine".to_owned(), "tiflash_compute".to_owned())]
+            .iter()
+            .cloned()
+            .collect();
+        assert!(config.server.labels == expected_labels);
+    }
+
+    {
+        let args = vec!["test_label", "--labels", "k=v", "--engine-label", "tiflash"];
+        let mut config = get_config(args, None);
+        assert!(config.validate().is_ok());
+        let expected_labels = [
+            ("engine".to_owned(), "tiflash".to_owned()),
+            ("k".to_owned(), "v".to_owned()),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        assert!(config.server.labels == expected_labels);
+    }
+
+    {
+        let args = vec![
+            "test_label",
+            "--labels",
+            "k=v,exclusive=no-data",
+            "--engine-label",
+            "tiflash_compute",
+        ];
+        let mut config = get_config(args, None);
+        assert!(config.validate().is_ok());
+        let expected_labels = [
+            ("engine".to_owned(), "tiflash_compute".to_owned()),
+            ("k".to_owned(), "v".to_owned()),
+            ("exclusive".to_owned(), "no-data".to_owned()),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        assert!(config.server.labels == expected_labels);
+    }
+
+    {
+        let args = vec!["test_label", "--engine-label", "tiflash"];
+        // server.labels define in tiflash_tikv.toml
+        let labels = Some(
+            r#"
+        k="v2"
+        abc="def"
+        "#,
+        );
+        let mut config = get_config(args, labels);
+        assert!(config.validate().is_ok());
+        let expected_labels = [
+            ("engine".to_owned(), "tiflash".to_owned()),
+            ("k".to_owned(), "v2".to_owned()),
+            ("abc".to_owned(), "def".to_owned()),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        assert!(config.server.labels == expected_labels);
+    }
+
+    {
+        let args = vec![
+            "test_label",
+            "--labels",
+            "k=v,a=b",
+            "--engine-label",
+            "tiflash",
+        ];
+        // server.labels define in tiflash_tikv.toml
+        let labels = Some(
+            r#"
+        k="v2"
+        abc="def"
+        "#,
+        );
+        let mut config = get_config(args, labels);
+        assert!(config.validate().is_ok());
+        // merge `server.labels` in tiflash_tikv.toml and `--labels` in command line
+        // "k=v" in `--labels` should be overwritten by "k=v2" in tiflash_tikv.toml
+        let expected_labels = [
+            ("engine".to_owned(), "tiflash".to_owned()),
+            ("k".to_owned(), "v2".to_owned()),
+            ("a".to_owned(), "b".to_owned()),
+            ("abc".to_owned(), "def".to_owned()),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        assert!(config.server.labels == expected_labels);
     }
 }

--- a/proxy_tests/proxy/shared/config.rs
+++ b/proxy_tests/proxy/shared/config.rs
@@ -218,17 +218,33 @@ fn test_config_proxy_engine_role_label() {
     let mut v: Vec<String> = vec![];
     let mut config = gen_tikv_config(&None, false, &mut v);
     let mut proxy_config = gen_proxy_config(&None, false, &mut v);
-    // case-1: If engine-role label not specified in arguments, it's none.
-    let args = vec!["test_config_proxy_default1", "--engine-label", "tiflash"];
-    let matches = App::new("RaftStore Proxy")
+    let app = App::new("RaftStore Proxy")
+        .arg(
+            Arg::with_name("labels")
+                .long("labels")
+                .alias("label")
+                .takes_value(true)
+                .value_name("KEY=VALUE")
+                .multiple(true)
+                .use_delimiter(true)
+                .require_delimiter(true)
+                .value_delimiter(",")
+                .help("Sets server labels")
+                .long_help(
+                    "Set the server labels. Uses `,` to separate kv pairs, like \
+                `zone=cn,disk=ssd`",
+                ),
+        )
         .arg(
             Arg::with_name("engine-label")
                 .long("engine-label")
                 .help("Set engine label")
                 .required(true)
                 .takes_value(true),
-        )
-        .get_matches_from(args);
+        );
+    // case-1: If engine-role label not specified in arguments, it's none.
+    let args = vec!["test_config_proxy_default1", "--engine-label", "tiflash"];
+    let matches = app.clone().get_matches_from(args);
     overwrite_config_with_cmd_args(&mut config, &mut proxy_config, &matches);
     address_proxy_config(&mut config, &proxy_config);
 
@@ -245,30 +261,14 @@ fn test_config_proxy_engine_role_label() {
 
     // case-2: If engine-role label specified in arguments, use it as engine-role
     // label.
-    const EXPECTED_ENGINE_ROLE_LABEL: &str = "write";
     let args = vec![
         "test_config_proxy_default1",
         "--engine-label",
         "tiflash",
-        "--engine-role-label",
-        EXPECTED_ENGINE_ROLE_LABEL,
+        "--labels",
+        "engine_role=write",
     ];
-    let matches = App::new("RaftStore Proxy")
-        .arg(
-            Arg::with_name("engine-label")
-                .long("engine-label")
-                .help("Set engine label")
-                .required(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("engine-role-label")
-                .long("engine-role-label")
-                .help("Set engine role label")
-                .required(true)
-                .takes_value(true),
-        )
-        .get_matches_from(args);
+    let matches = app.clone().get_matches_from(args);
     overwrite_config_with_cmd_args(&mut config, &mut proxy_config, &matches);
     address_proxy_config(&mut config, &proxy_config);
     assert_eq!(
@@ -277,7 +277,7 @@ fn test_config_proxy_engine_role_label() {
             .labels
             .get(DEFAULT_ENGINE_ROLE_LABEL_KEY)
             .unwrap(),
-        EXPECTED_ENGINE_ROLE_LABEL
+        "write"
     );
 }
 

--- a/proxy_tests/proxy/shared/config.rs
+++ b/proxy_tests/proxy/shared/config.rs
@@ -242,7 +242,8 @@ fn test_config_proxy_engine_role_label() {
                 .required(true)
                 .takes_value(true),
         );
-    // case-1: If engine-role label not specified in arguments, it's none.
+    // case-1: If engine-role label specified in neither the argument `--labels` nor
+    // proxy's config file, it's none.
     let args = vec!["test_config_proxy_default1", "--engine-label", "tiflash"];
     let matches = app.clone().get_matches_from(args);
     overwrite_config_with_cmd_args(&mut config, &mut proxy_config, &matches);
@@ -259,8 +260,8 @@ fn test_config_proxy_engine_role_label() {
         true
     );
 
-    // case-2: If engine-role label specified in arguments, use it as engine-role
-    // label.
+    // case-2: If engine-role label specified in the argument `--label`, use it as
+    // engine-role label.
     let args = vec![
         "test_config_proxy_default1",
         "--engine-label",

--- a/proxy_tests/proxy/shared/fast_add_peer/fp.rs
+++ b/proxy_tests/proxy/shared/fast_add_peer/fp.rs
@@ -981,7 +981,7 @@ fn test_msgsnapshot_before_msgappend() {
     debug!("compact at index {}", compact_index);
     let compact_log = test_raftstore::new_compact_log_request(compact_index, compact_term);
     let req = test_raftstore::new_admin_request(1, region.get_region_epoch(), compact_log);
-    let res = cluster
+    let _res = cluster
         .call_command_on_leader(req, Duration::from_secs(3))
         .unwrap();
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref https://github.com/pingcap/tiflash/issues/9750

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
* Remove param `--engine-role-label`
* Specify extra store labels by param `--labels`
  * If there are duplicated key in `server.labels` and `--labels`, use the one in `server.labels`
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
