### PR TITLE
Specify extra store labels by param `--labels` (#420) (release-8.5)

### DIFF
--- a/proxy_components/proxy_server/src/proxy.rs
+++ b/proxy_components/proxy_server/src/proxy.rs
@@ -202,22 +202,6 @@ pub unsafe fn run_proxy(
                 .long_help("Set the PD endpoints to use. Use `,` to separate multiple PDs"),
         )
         .arg(
-            Arg::with_name("labels")
-                .long("labels")
-                .alias("label")
-                .takes_value(true)
-                .value_name("KEY=VALUE")
-                .multiple(true)
-                .use_delimiter(true)
-                .require_delimiter(true)
-                .value_delimiter(",")
-                .help("Sets server labels")
-                .long_help(
-                    "Set the server labels. Uses `,` to separate kv pairs, like \
-                     `zone=cn,disk=ssd`",
-                ),
-        )
-        .arg(
             Arg::with_name("print-sample-config")
                 .long("print-sample-config")
                 .help("Print a sample config to stdout"),
@@ -264,6 +248,22 @@ pub unsafe fn run_proxy(
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("labels")
+                .long("labels")
+                .alias("label")
+                .takes_value(true)
+                .value_name("KEY=VALUE")
+                .multiple(true)
+                .use_delimiter(true)
+                .require_delimiter(true)
+                .value_delimiter(",")
+                .help("Sets server labels")
+                .long_help(
+                    "Set the server labels. Uses `,` to separate kv pairs, like \
+                     `zone=cn,disk=ssd`",
+                ),
+        )
+        .arg(
             Arg::with_name("engine-label")
                 .long("engine-label")
                 .help("Set engine label")
@@ -274,12 +274,6 @@ pub unsafe fn run_proxy(
             Arg::with_name("only-decryption")
                 .long("only-decryption")
                 .help("Only do decryption in Proxy"),
-        )
-        .arg(
-            Arg::with_name("engine-role-label")
-                .long("engine-role-label")
-                .help("Set engine role label")
-                .takes_value(true),
         )
         .arg(
             Arg::with_name("memory-limit-size")

--- a/proxy_tests/proxy/shared/fast_add_peer/fp.rs
+++ b/proxy_tests/proxy/shared/fast_add_peer/fp.rs
@@ -981,7 +981,7 @@ fn test_msgsnapshot_before_msgappend() {
     debug!("compact at index {}", compact_index);
     let compact_log = test_raftstore::new_compact_log_request(compact_index, compact_term);
     let req = test_raftstore::new_admin_request(1, region.get_region_epoch(), compact_log);
-    let res = cluster
+    let _res = cluster
         .call_command_on_leader(req, Duration::from_secs(3))
         .unwrap();
 


### PR DESCRIPTION
cherry-pick of https://github.com/pingcap/tidb-engine-ext/pull/420

ref pingcap/tiflash#9750

* Remove param `--engine-role-label`
* Specify extra store labels by param `--labels`
  * If there are duplicated key in `server.labels` and `--labels`, use the one in `server.labels`

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
