### PR TITLE
FFI: Use CppStrWithView as the return type of fn_get_lock_by_key

### DIFF
--- a/gen-proxy-ffi.sh
+++ b/gen-proxy-ffi.sh
@@ -4,4 +4,6 @@ set -ex
 
 ffi_path="raftstore-proxy/ffi"
 ./${ffi_path}/format.sh
+# Generate the rust code according to the files
+# under "${ffi_path}"
 cargo run --package gen-proxy-ffi --bin gen_proxy_ffi

--- a/gen-proxy-ffi/src/lib.rs
+++ b/gen-proxy-ffi/src/lib.rs
@@ -110,7 +110,10 @@ pub fn gen_ffi_code() {
             println!("    {}", f);
         }
         if ori_version == hash_version {
-            println!("hash version equal, version={}, SKIP overwrite version", ori_version);
+            println!(
+                "hash version equal, version={}, SKIP overwrite version",
+                ori_version
+            );
         } else {
             println!(
                 "Original hash version is {}, start to generate rust code with new version {}",

--- a/gen-proxy-ffi/src/lib.rs
+++ b/gen-proxy-ffi/src/lib.rs
@@ -100,20 +100,20 @@ pub fn gen_ffi_code() {
 
     let ori_version = read_version_file(&version_cpp_file);
     println!("\nFFI src dir path is {}", src_dir);
-    println!("Original version is {}", ori_version);
+    println!("Original hash version is {}", ori_version);
 
     let (headers, hash_version) = scan_ffi_src_head(&src_dir);
 
     {
-        println!("Scan and get src files");
+        println!("Scanning src files");
         for f in &headers {
             println!("    {}", f);
         }
         if ori_version == hash_version {
-            println!("Check hash version equal & NOT overwrite version");
+            println!("hash version equal, version={}, SKIP overwrite version", ori_version);
         } else {
             println!(
-                "Current hash version is {}, start to generate rust code with version {}",
+                "Original hash version is {}, start to generate rust code with new version {}",
                 ori_version, hash_version
             );
             make_version_file(hash_version, &version_cpp_file);

--- a/proxy_components/mock-engine-store/src/mock_store/mock_engine_store_server.rs
+++ b/proxy_components/mock-engine-store/src/mock_store/mock_engine_store_server.rs
@@ -632,20 +632,33 @@ unsafe extern "C" fn ffi_get_lock_by_key(
     arg1: *const interfaces_ffi::EngineStoreServerWrap,
     region_id: u64,
     key: interfaces_ffi::BaseBuffView,
-) -> interfaces_ffi::BaseBuffView {
+) -> interfaces_ffi::CppStrWithView {
     let store = into_engine_store_server_wrap(arg1);
     match (*store.engine_store_server).kvstore.get(&region_id) {
         Some(e) => {
             let cf_index = interfaces_ffi::ColumnFamilyType::Lock as usize;
             let value = e.data[cf_index].get(key.to_slice()).unwrap().as_ptr();
-            interfaces_ffi::BaseBuffView {
-                data: value as *const i8,
-                len: 0,
+            interfaces_ffi::CppStrWithView {
+                // hack
+                inner: interfaces_ffi::RawCppPtr {
+                    ptr: std::ptr::null_mut(),
+                    type_: 1,
+                },
+                view: interfaces_ffi::BaseBuffView {
+                    data: value as *const i8,
+                    len: 0,
+                },
             }
         }
-        None => interfaces_ffi::BaseBuffView {
-            data: std::ptr::null(),
-            len: 0,
+        None => interfaces_ffi::CppStrWithView {
+            inner: interfaces_ffi::RawCppPtr {
+                ptr: std::ptr::null_mut(),
+                type_: 1,
+            },
+            view: interfaces_ffi::BaseBuffView {
+                data: std::ptr::null(),
+                len: 0,
+            },
         },
     }
 }

--- a/proxy_components/proxy_ffi/src/engine_store_helper_impls.rs
+++ b/proxy_components/proxy_ffi/src/engine_store_helper_impls.rs
@@ -504,6 +504,7 @@ impl EngineStoreServerHelper {
 
     pub fn get_lock_by_key(&self, region_id: u64, key: &[u8]) -> Vec<u8> {
         unsafe { (self.fn_get_lock_by_key.into_inner())(self.inner, region_id, key.into()) }
+            .view
             .to_slice()
             .to_vec()
     }

--- a/proxy_components/proxy_ffi/src/interfaces.rs
+++ b/proxy_components/proxy_ffi/src/interfaces.rs
@@ -748,7 +748,7 @@ pub mod root {
                     arg1: *const root::DB::EngineStoreServerWrap,
                     arg2: u64,
                     arg3: root::DB::BaseBuffView,
-                ) -> root::DB::BaseBuffView,
+                ) -> root::DB::CppStrWithView,
             >,
             pub fn_query_fap_snapshot_state: ::std::option::Option<
                 unsafe extern "C" fn(
@@ -793,7 +793,7 @@ pub mod root {
                 arg3: root::DB::RawVoidPtr,
             ) -> u32;
         }
-        pub const RAFT_STORE_PROXY_VERSION: u64 = 2149052863435660119;
+        pub const RAFT_STORE_PROXY_VERSION: u64 = 10558255710263971014;
         pub const RAFT_STORE_PROXY_MAGIC_NUMBER: u32 = 324508639;
     }
 }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/@version
@@ -1,3 +1,3 @@
 #pragma once
 #include <cstdint>
-namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 2149052863435660119ull; }
+namespace DB { constexpr uint64_t RAFT_STORE_PROXY_VERSION = 10558255710263971014ull; }

--- a/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
+++ b/raftstore-proxy/ffi/src/RaftStoreProxyFFI/ProxyFFI.h
@@ -381,8 +381,8 @@ struct EngineStoreServerHelper {
                                    uint64_t leader_safe_ts);
   FastAddPeerRes (*fn_fast_add_peer)(EngineStoreServerWrap *,
                                      uint64_t region_id, uint64_t new_peer_id);
-  BaseBuffView (*fn_get_lock_by_key)(const EngineStoreServerWrap *, uint64_t,
-                                     BaseBuffView);
+  CppStrWithView (*fn_get_lock_by_key)(const EngineStoreServerWrap *, uint64_t,
+                                       BaseBuffView);
   FapSnapshotState (*fn_query_fap_snapshot_state)(EngineStoreServerWrap *,
                                                   uint64_t region_id,
                                                   uint64_t new_peer_id,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/pingcap/tiflash/issues/9915

Using `BaseBuffView` as the return type of `fn_get_lock_by_key` is not memory safe.

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
FFI: Use CppStrWithView as the return type of fn_get_lock_by_key
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
