### PR TITLE
[release-9.0-beta.1] Cherry-pick tikv#18328

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,6 +2548,7 @@ dependencies = [
  "chrono",
  "cloud",
  "encryption",
+ "fail",
  "file_system",
  "futures 0.3.15",
  "futures-io",

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
+[features]
+failpoints = ["fail/failpoints"]
+
 [dependencies]
 async-compression = { version = "0.4.12", features = ["futures-io", "zstd"] }
 async-trait = "0.1"
@@ -13,6 +16,7 @@ azure = { workspace = true }
 chrono = { workspace = true }
 cloud = { workspace = true }
 encryption = { workspace = true }
+fail = "0.5"
 file_system = { workspace = true }
 futures = "0.3"
 futures-io = "0.3"

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -507,7 +507,13 @@ impl<E: KvEngine> SstImporter<E> {
             })?;
         }
 
-        let ext_storage = self.external_storage_or_cache(backend, cache_key)?;
+        // The `DashMap` locks the entry to ensure that only one thread loads the
+        // credentials at a time. However, if the thread gets blocked during the
+        // loading process, it can lead to a deadlock. To avoid this, blocking
+        // operations must be performed outside of the `DashMap`.
+        let ext_storage = tokio::task::block_in_place(move || {
+            self.external_storage_or_cache(backend, cache_key)
+        })?;
         let ext_storage = self.auto_encrypt_local_file_if_needed(ext_storage);
 
         let result = ext_storage
@@ -2577,15 +2583,17 @@ mod tests {
 
         // test do_download_kv_file().
         assert!(importer.download_to_disk_only());
-        let output = block_on_external_io(importer.download_kv_file(
-            &kv_meta,
-            ext_storage,
-            &backend,
-            &Limiter::new(f64::INFINITY),
-            None,
-            Vec::new(),
-        ))
-        .unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let output = runtime
+            .block_on(importer.download_kv_file(
+                &kv_meta,
+                ext_storage,
+                &backend,
+                &Limiter::new(f64::INFINITY),
+                None,
+                Vec::new(),
+            ))
+            .unwrap();
         assert_eq!(*output, buff);
         check_file_exists(&path.save, Some(&*key_manager));
 
@@ -3872,15 +3880,17 @@ mod tests {
             )
             .unwrap();
 
-        let output = block_on_external_io(importer.download_kv_file(
-            &kv_meta,
-            ext_storage,
-            &storage_backend,
-            &Limiter::new(f64::INFINITY),
-            opt_cipher_info,
-            master_key_configs,
-        ))
-        .unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let output = runtime
+            .block_on(importer.download_kv_file(
+                &kv_meta,
+                ext_storage,
+                &storage_backend,
+                &Limiter::new(f64::INFINITY),
+                opt_cipher_info,
+                master_key_configs,
+            ))
+            .unwrap();
         assert_eq!(*output, file_content);
         if !in_mem {
             check_file_exists(&path.save, opt_key_manager.as_deref());

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -23,6 +23,74 @@ use self::util::{
     open_cluster_and_tikv_import_client_v2,
 };
 
+#[test]
+fn test_concurrent_download_sst() {
+    let mut config = TikvConfig::default();
+    config.import.num_threads = 4;
+    let (_cluster, ctx, tikv, import) = open_cluster_and_tikv_import_client(Some(config));
+    let temp_dir = Builder::new()
+        .prefix("test_concurrent_download_sst")
+        .tempdir()
+        .unwrap();
+
+    fail::cfg("create_local_storage_yield", "return(1000)").unwrap();
+    let metas = Arc::new(Mutex::new(Vec::new()));
+    let threads: Vec<_> = (0..10)
+        .map(|i| {
+            let file_name = format!("test_{}.sst", i);
+            let temp_path = temp_dir.path().to_owned();
+            let sst_path = temp_path.join(&file_name);
+            let sst_range = (i, (i + 1) * 2);
+            let (mut meta, _) = gen_sst_file(sst_path, sst_range);
+            meta.set_region_id(ctx.get_region_id());
+            meta.set_region_epoch(ctx.get_region_epoch().clone());
+            let metas = Arc::clone(&metas);
+            let import = import.clone();
+
+            std::thread::spawn(move || {
+                // Run multiple concurrent downloads
+                let mut download = DownloadRequest::default();
+                download.set_sst(meta.clone());
+                download.set_storage_backend(external_storage::make_local_backend(&temp_path));
+                download.set_name(file_name);
+                // make the same cache key for different requests,
+                // so that dashmap will get a lock with same entry.
+                // to verify there is no dead locks.
+                download.set_storage_cache_id("cache".to_string());
+                download.mut_sst().mut_range().set_start(vec![sst_range.1]);
+                download
+                    .mut_sst()
+                    .mut_range()
+                    .set_end(vec![sst_range.1 + 1]);
+                download.mut_sst().mut_range().set_start(Vec::new());
+                download.mut_sst().mut_range().set_end(Vec::new());
+                let download = download.clone();
+
+                let result: DownloadResponse = import.download(&download).unwrap();
+                assert!(!result.get_is_empty());
+                assert_eq!(result.get_range().get_start(), &[sst_range.0]);
+                assert_eq!(result.get_range().get_end(), &[sst_range.1 - 1]);
+                // Only store meta after successful download
+                metas.lock().unwrap().push((meta, sst_range));
+                println!("Thread {} completed download", i);
+            })
+        })
+        .collect();
+
+    // Wait for all downloads to complete
+    for handle in threads {
+        handle.join().unwrap();
+    }
+    fail::remove("create_local_storage_yield");
+
+    // Now ingest all SSTs in order
+    let metas = metas.lock().unwrap();
+    for (meta, sst_range) in metas.iter() {
+        must_ingest_sst(&import, ctx.clone(), meta.clone());
+        check_ingested_kvs(&tikv, &ctx, *sst_range);
+    }
+}
+
 // Opening sst writer involves IO operation, it may block threads for a while.
 // Test if download sst works when opening sst writer is blocked.
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/pingcap/tiflash/issues/10032

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

cherry-pick https://github.com/tikv/tikv/pull/18330 to fix that BR restore may hang tiflash-proxy

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
