### PR TITLE
Fix the path label of req is not trim as expected

### DIFF
--- a/proxy_components/proxy_server/src/status_server/mod.rs
+++ b/proxy_components/proxy_server/src/status_server/mod.rs
@@ -856,10 +856,7 @@ where
 
                         // limit the path label by prefix to reduce the number of labels
                         // in prometheus
-                        const PROXY_PREFIXES: [&str; 2] = [
-                            "/region",
-                            "/log-level",
-                        ];
+                        const PROXY_PREFIXES: [&str; 2] = ["/region", "/log-level"];
                         // TODO: consider trim the tiflash prefix in tiflash FFI
                         // calls to make it more easier to maintain.
                         const TIFLASH_PREFIXES: [&str; 8] = [
@@ -873,10 +870,14 @@ where
                             "/tiflash/remote/upload",
                         ];
                         let find_matching_prefix = |path: &str| -> String {
-                            if let Some(prefix) = PROXY_PREFIXES.iter().find(|&&p| path.starts_with(p)) {
+                            if let Some(prefix) =
+                                PROXY_PREFIXES.iter().find(|&&p| path.starts_with(p))
+                            {
                                 return prefix.to_string();
                             }
-                            if let Some(prefix) = TIFLASH_PREFIXES.iter().find(|&&p| path.starts_with(p)) {
+                            if let Some(prefix) =
+                                TIFLASH_PREFIXES.iter().find(|&&p| path.starts_with(p))
+                            {
                                 return prefix.to_string();
                             }
                             // If no prefix matches, return the original path

--- a/proxy_components/proxy_server/src/status_server/mod.rs
+++ b/proxy_components/proxy_server/src/status_server/mod.rs
@@ -814,7 +814,7 @@ where
                             }
                             // This interface is used for configuration file hosting scenarios,
                             // TiKV will not update configuration files, and this interface will
-                            // silently ignore configration items that cannot be updated online,
+                            // silently ignore configuration items that cannot be updated online,
                             // hand it over to the hosting platform for processing.
                             (Method::PUT, "/config/reload") => {
                                 Self::update_config_from_toml_file(cfg_controller.clone(), req)
@@ -853,12 +853,16 @@ where
                                 ))
                             }
                         };
-                        let path_label = if is_unknown_path {
-                            "unknown".to_owned()
-                        } else {
-                            path
-                        };
-                        const TIFLASH_PREFIXES: &[&str] = &[
+
+                        // limit the path label by prefix to reduce the number of labels
+                        // in prometheus
+                        const PROXY_PREFIXES: [&str; 2] = [
+                            "/region",
+                            "/log-level",
+                        ];
+                        // TODO: consider trim the tiflash prefix in tiflash FFI
+                        // calls to make it more easier to maintain.
+                        const TIFLASH_PREFIXES: [&str; 8] = [
                             "/tiflash/sync-status",
                             "/tiflash/sync-region",
                             "/tiflash/sync-schema",
@@ -868,25 +872,24 @@ where
                             "/tiflash/remote/gc",
                             "/tiflash/remote/upload",
                         ];
-
-                        let get_tiflash_prefix = |path: &str| -> Option<&'static str> {
-                            TIFLASH_PREFIXES
-                                .iter()
-                                .find(|&&p| path.starts_with(p))
-                                .copied()
-                        };
-                        match get_tiflash_prefix(method.as_str()) {
-                            None => {
-                                STATUS_REQUEST_DURATION
-                                    .with_label_values(&[method.as_str(), &path_label])
-                                    .observe(start.elapsed().as_secs_f64());
+                        let find_matching_prefix = |path: &str| -> String {
+                            if let Some(prefix) = PROXY_PREFIXES.iter().find(|&&p| path.starts_with(p)) {
+                                return prefix.to_string();
                             }
-                            Some(s) => {
-                                STATUS_REQUEST_DURATION
-                                    .with_label_values(&[s, &path_label])
-                                    .observe(start.elapsed().as_secs_f64());
+                            if let Some(prefix) = TIFLASH_PREFIXES.iter().find(|&&p| path.starts_with(p)) {
+                                return prefix.to_string();
                             }
+                            // If no prefix matches, return the original path
+                            path.to_string()
                         };
+                        let limited_path_label = if is_unknown_path {
+                            "unknown".to_owned()
+                        } else {
+                            find_matching_prefix(&path)
+                        };
+                        STATUS_REQUEST_DURATION
+                            .with_label_values(&[method.as_str(), &limited_path_label])
+                            .observe(start.elapsed().as_secs_f64());
                         res
                     }
                 }))


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

The original code in https://github.com/pingcap/tidb-engine-ext/pull/439 can not trim the prefix as expected
https://github.com/CalvinNeo/tidb-engine-ext/blob/77edcd3433a3a0310fd70a1ebc323a87191e30f6/proxy_components/proxy_server/src/status_server/mod.rs#L878-L889

`get_tiflash_prefix(method.as_str())` should be `get_tiflash_prefix(path_label.as_str())`

```
STATUS_REQUEST_DURATION
                                    .with_label_values(&[s, &path_label])
                                    .observe(start.elapsed().as_secs_f64());
```

shouold be 
```
STATUS_REQUEST_DURATION
                                    .with_label_values(&[method, &sl])
                                    .observe(start.elapsed().as_secs_f64());
```

Before this PR
<img width="4310" height="1800" alt="image" src="https://github.com/user-attachments/assets/d549a218-cdb9-4afc-a2b6-ef89def13bcb" />

After this PR
<img width="4296" height="1822" alt="image" src="https://github.com/user-attachments/assets/4b366497-ab0b-4f4c-bc1c-4a9207e4a18b" />

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
