### PR TITLE
degrade TiKV Error log level for false alarms

### DIFF
--- a/components/concurrency_manager/src/lib.rs
+++ b/components/concurrency_manager/src/lib.rs
@@ -143,7 +143,7 @@ impl ConcurrencyManager {
         };
 
         if limit_valid_duration >= max_ts_drift_allowance {
-            error!("improper setting: limit_valid_duration >= max_ts_drift_allowance; \
+            warn!("improper setting: limit_valid_duration >= max_ts_drift_allowance; \
                 consider increasing storage.max-ts.max-drift or decreasing storage.max-ts.cache-sync-interval";
                 "limit_valid_duration" => ?limit_valid_duration,
                 "max_ts_drift_allowance" => ?max_ts_drift_allowance,

--- a/components/in_memory_engine/src/region_label.rs
+++ b/components/in_memory_engine/src/region_label.rs
@@ -15,7 +15,7 @@ use pd_client::{
     Error as PdError, PdClient, RpcClient, REGION_LABEL_PATH_PREFIX,
 };
 use serde::{Deserialize, Serialize};
-use tikv_util::{error, info, timer::GLOBAL_TIMER_HANDLE};
+use tikv_util::{error, info, timer::GLOBAL_TIMER_HANDLE, warn};
 
 /// RegionLabel is the label of a region. This struct is partially copied from
 /// https://github.com/tikv/pd/blob/783d060861cef37c38cbdcab9777fe95c17907fe/server/schedule/labeler/rules.go#L31.
@@ -239,7 +239,7 @@ impl RegionLabelService {
                         });
                     }
                     Err(PdError::DataCompacted(msg)) => {
-                        error!("ime required revision has been compacted"; "err" => ?msg);
+                        warn!("ime required revision has been compacted"; "err" => ?msg);
                         self.reload_all_region_labels().await;
                         cancel.abort();
                         continue 'outer;

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -652,7 +652,7 @@ impl PdClient for RpcClient {
                             info!("cancel region heartbeat sender");
                         }
                         Err(e) => {
-                            error!(?e; "failed to send heartbeat");
+                            warn!("failed to send heartbeat"; "err" => ?e);
                         }
                     };
                 });

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -494,7 +494,7 @@ where
             Err(err) => {
                 // these errors are not caused by network, no need to retry
                 if err.retryable() && self.remain_request_count > 0 {
-                    error!(?*err; "request failed, retry");
+                    warn!("request failed, retry"; "err" => ?*err);
                     false
                 } else {
                     true
@@ -550,7 +550,7 @@ where
                 return Ok(r);
             }
             Err(e) => {
-                error!(?e; "request failed");
+                warn!("request failed"; "err" => ?e);
                 if retry == 0 {
                     return Err(e);
                 }
@@ -559,7 +559,7 @@ where
         // try reconnect
         retry -= 1;
         if let Err(e) = block_on(client.reconnect(true)) {
-            error!(?e; "reconnect failed");
+            warn!("reconnect failed"; "err" => ?e);
             thread::sleep(REQUEST_RECONNECT_INTERVAL);
         }
     }
@@ -718,7 +718,7 @@ impl PdConnector {
                         }
                     }
                     Err(e) => {
-                        error!("connect failed"; "endpoints" => ep, "error" => ?e);
+                        warn!("connect failed"; "endpoints" => ep, "error" => ?e);
                         continue;
                     }
                 }

--- a/components/raftstore-v2/src/operation/command/write/ingest.rs
+++ b/components/raftstore-v2/src/operation/command/write/ingest.rs
@@ -9,7 +9,7 @@ use raftstore::{
     store::{check_sst_for_ingestion, metrics::PEER_WRITE_CMD_COUNTER, util},
     Result,
 };
-use slog::{error, info};
+use slog::{error, info, warn};
 use sst_importer::range_overlaps;
 use tikv_util::{box_try, slog_panic};
 
@@ -25,7 +25,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
     #[inline]
     pub fn on_cleanup_import_sst(&mut self) {
         if let Err(e) = self.fsm.store.on_cleanup_import_sst(self.store_ctx) {
-            error!(self.fsm.store.logger(), "cleanup import sst failed"; "error" => ?e);
+            warn!(self.fsm.store.logger(), "cleanup import sst failed"; "error" => ?e);
         }
         self.schedule_tick(
             StoreTick::CleanupImportSst,

--- a/components/raftstore-v2/src/operation/misc.rs
+++ b/components/raftstore-v2/src/operation/misc.rs
@@ -12,7 +12,7 @@ use raftstore::{
     store::{CompactThreshold, TabletSnapKey},
     Result,
 };
-use slog::{debug, error, info};
+use slog::{debug, error, info, warn};
 
 use crate::{
     batch::StoreContext,
@@ -117,7 +117,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
     #[inline]
     pub fn on_snapshot_gc(&mut self) {
         if let Err(e) = self.fsm.store.on_snapshot_gc(self.store_ctx) {
-            error!(self.fsm.store.logger(), "cleanup import sst failed"; "error" => ?e);
+            warn!(self.fsm.store.logger(), "cleanup import sst failed"; "error" => ?e);
         }
         self.schedule_tick(
             StoreTick::SnapGc,

--- a/components/raftstore-v2/src/worker/pd/mod.rs
+++ b/components/raftstore-v2/src/worker/pd/mod.rs
@@ -527,7 +527,7 @@ mod requests {
             None => PeerMsg::admin_command(req).0,
         };
         if let Err(e) = router.send(region_id, msg) {
-            error!(
+            warn!(
                 logger,
                 "send request failed";
                 "region_id" => region_id, "cmd_type" => ?cmd_type, "err" => ?e,

--- a/components/raftstore-v2/src/worker/pd/store.rs
+++ b/components/raftstore-v2/src/worker/pd/store.rs
@@ -366,7 +366,7 @@ where
                     }
                 }
                 Err(e) => {
-                    error!(logger, "store heartbeat failed"; "err" => ?e);
+                    warn!(logger, "store heartbeat failed"; "err" => ?e);
                 }
             }
         };

--- a/components/raftstore/src/compacted_event_sender.rs
+++ b/components/raftstore/src/compacted_event_sender.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 
 use engine_rocks::{CompactedEventSender, RocksCompactedEvent};
 use engine_traits::{KvEngine, RaftEngine};
-use tikv_util::error_unknown;
+use tikv_util::warn;
 
 use crate::store::{fsm::store::RaftRouter, StoreMsg};
 
@@ -25,7 +25,10 @@ where
         let router = self.router.lock().unwrap();
         let event = StoreMsg::CompactedEvent(event);
         if let Err(e) = router.send_control(event) {
-            error_unknown!(?e; "send compaction finished event to raftstore failed");
+            warn!(
+                "send compaction finished event to raftstore failed";
+                "err" => ?e,
+            );
         }
     }
 }

--- a/components/raftstore/src/coprocessor/split_observer.rs
+++ b/components/raftstore/src/coprocessor/split_observer.rs
@@ -5,7 +5,7 @@ use kvproto::{
     metapb::Region,
     raft_cmdpb::{AdminCmdType, AdminRequest, SplitRequest},
 };
-use tikv_util::{box_err, box_try, codec::bytes, error, warn};
+use tikv_util::{box_err, box_try, codec::bytes, warn};
 
 use super::{AdminObserver, Coprocessor, ObserverContext, Result as CopResult};
 use crate::{store::util, Error};
@@ -124,7 +124,7 @@ impl AdminObserver for SplitObserver {
                 }
                 let mut request = vec![req.take_split()];
                 if let Err(e) = self.on_split(ctx, &mut request) {
-                    error!(
+                    warn!(
                         "failed to handle split req";
                         "region_id" => ctx.region().get_id(),
                         "err" => ?e,
@@ -145,7 +145,7 @@ impl AdminObserver for SplitObserver {
                 }
                 let mut requests = req.mut_splits().take_requests().into();
                 if let Err(e) = self.on_split(ctx, &mut requests) {
-                    error!(
+                    warn!(
                         "failed to handle split req";
                         "region_id" => ctx.region().get_id(),
                         "err" => ?e,

--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -1140,7 +1140,7 @@ impl<EK: KvEngine, ER: RaftEngine> EntryStorage<EK, ER> {
             Ok(_) => {
                 // This should not happen, but it's OK :)
                 debug_assert!(false, "entries should not have been fetched");
-                error!("entries are fetched unexpectedly during warming up");
+                warn!("entries are fetched unexpectedly during warming up");
                 None
             }
             Err(raft::Error::Store(raft::StorageError::LogTemporarilyUnavailable)) => {
@@ -1187,7 +1187,7 @@ impl<EK: KvEngine, ER: RaftEngine> EntryStorage<EK, ER> {
                         // FIXME: the assertion below doesn't hold.
                         // assert!(is_valid, "the warmup range should still be valid");
                         if !is_valid {
-                            error!(
+                            warn!(
                                 "unexpected warmup state";
                                 "region_id" => self.region_id,
                                 "peer_id" => self.peer_id,

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -666,10 +666,10 @@ where
                     if !self.ctx.coprocessor_host.on_raft_message(&msg.msg) {
                         continue;
                     }
-
                     if let Err(e) = self.on_raft_message(msg) {
-                        error!(%e;
+                        warn!(
                             "handle raft message err";
+                            "err" => ?e,
                             "region_id" => self.fsm.region_id(),
                             "peer_id" => self.fsm.peer_id(),
                         );
@@ -2274,7 +2274,7 @@ where
             Some(mb) => mb,
             None => {
                 self.fsm.tick_registry[idx] = false;
-                error!(
+                warn!(
                     "failed to get mailbox";
                     "region_id" => self.fsm.region_id(),
                     "peer_id" => self.fsm.peer_id(),
@@ -3223,7 +3223,7 @@ where
         }
 
         if !msg.has_region_epoch() {
-            error!(
+            warn!(
                 "missing epoch in raft message, ignore it";
                 "region_id" => region_id,
             );
@@ -4163,7 +4163,7 @@ where
         );
         let task = PdTask::DestroyPeer { region_id };
         if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
-            error!(
+            warn!(
                 "failed to notify pd";
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
@@ -4536,7 +4536,7 @@ where
                 regions: regions.to_vec(),
             };
             if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
-                error!(
+                warn!(
                     "failed to notify pd";
                     "region_id" => self.fsm.region_id(),
                     "peer_id" => self.fsm.peer_id(),
@@ -6439,7 +6439,7 @@ where
             callback: cb,
         };
         if let Err(ScheduleError::Stopped(t)) = self.ctx.pd_scheduler.schedule(task) {
-            error!(
+            warn!(
                 "failed to notify pd to split: Stopped";
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
@@ -6894,7 +6894,7 @@ where
                     region: self.fsm.peer.region().clone(),
                 };
                 if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
-                    error!(
+                    warn!(
                         "failed to notify pd";
                         "region_id" => self.fsm.region_id(),
                         "peer_id" => self.fsm.peer_id(),

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -732,8 +732,9 @@ where
             gc_msg.set_is_tombstone(true);
         }
         if let Err(e) = self.trans.send(gc_msg) {
-            error!(?e;
+            warn!(
                 "send gc message failed";
+                "err" => ?e,
                 "region_id" => region_id,
                 "to_peer_id" => ?from_peer.get_id(),
                 "to_peer_store_id" => ?from_peer.get_store_id(),
@@ -2170,8 +2171,9 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                     extra_msg.set_type(ExtraMessageType::MsgCheckStalePeerResponse);
                     extra_msg.set_check_peers(region.get_peers().into());
                     if let Err(e) = self.ctx.trans.send(send_msg) {
-                        error!(?e;
+                        warn!(
                             "send check stale peer response message failed";
+                            "err" => ?e,
                             "region_id" => region_id,
                         );
                     }
@@ -2252,7 +2254,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         }
 
         if !msg.has_region_epoch() {
-            error!(
+            warn!(
                 "missing epoch in raft message, ignore it";
                 "region_id" => region_id,
             );
@@ -3292,9 +3294,10 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
 
     fn on_cleanup_import_sst_tick(&mut self) {
         if let Err(e) = self.on_cleanup_import_sst() {
-            error!(?e;
+            warn!(
                 "cleanup import sst failed";
                 "store_id" => self.fsm.store.id,
+                "err" => ?e,
             );
         }
         self.register_cleanup_import_sst_tick();

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4267,7 +4267,7 @@ where
                     region_id: self.region_id,
                 };
                 if let Err(e) = poll_ctx.pd_scheduler.schedule(task) {
-                    error!(
+                    warn!(
                         "failed to notify pd";
                         "region_id" => self.region_id,
                         "peer_id" => self.peer_id(),
@@ -5854,7 +5854,7 @@ where
             wait_data_peers: self.wait_data_peers.clone(),
         });
         if let Err(e) = ctx.pd_scheduler.schedule(task) {
-            error!(
+            warn!(
                 "failed to notify pd";
                 "region_id" => self.region_id,
                 "peer_id" => self.peer.get_id(),
@@ -5891,8 +5891,9 @@ where
         send_msg.set_extra_msg(msg);
         send_msg.set_to_peer(to.clone());
         if let Err(e) = trans.send(send_msg) {
-            error!(?e;
+            warn!(
                 "failed to send extra message";
+                "err" => ?e,
                 "type" => ?ty,
                 "region_id" => self.region_id,
                 "peer_id" => self.peer.get_id(),

--- a/components/raftstore/src/store/worker/cleanup_snapshot.rs
+++ b/components/raftstore/src/store/worker/cleanup_snapshot.rs
@@ -148,7 +148,10 @@ where
 
                 let msg = StoreMsg::GcSnapshotFinish;
                 if let Err(e) = StoreRouter::send(&self.router, msg) {
-                    error!(%e; "send StoreMsg::GcSnapshotFinish failed");
+                    warn!(
+                        "send StoreMsg::GcSnapshotFinish failed, are we shutting down?";
+                        "err" => ?e,
+                    );
                 }
             }
             Task::DeleteSnapshotFiles {

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1511,7 +1511,7 @@ where
                         .inc();
                 }
                 Err(e) => {
-                    error!("get region failed"; "err" => ?e);
+                    warn!("get region failed"; "err" => ?e);
                 }
             }
         };
@@ -2139,7 +2139,7 @@ where
                                 cb: Callback::None,
                             });
                             if let Err(e) = router.send(region_id, PeerMsg::CasualMessage(msg)) {
-                                error!("send auto half split request failed";
+                                warn!("send auto half split request failed";
                                     "region_id" => region_id,
                                     "start_key" => log_wrappers::Value::key(&start_key),
                                     "end_key" => log_wrappers::Value::key(&end_key),

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -571,7 +571,7 @@ where
             .unwrap();
         // Remove all overlapped ranges directly without ingesting.
         if let Err(e) = self.delete_all_in_range(&ranges, true, false) {
-            error!("failed to cleanup stale range"; "err" => %e);
+            warn!("failed to cleanup stale range"; "err" => %e);
             return;
         }
         // Clear related blob files belonging to the given range directly after clearing

--- a/components/resource_control/src/service.rs
+++ b/components/resource_control/src/service.rs
@@ -17,7 +17,7 @@ use pd_client::{
     RESOURCE_CONTROL_CONTROLLER_CONFIG_PATH,
 };
 use serde::{Deserialize, Serialize};
-use tikv_util::{error, info, timer::GLOBAL_TIMER_HANDLE};
+use tikv_util::{error, info, timer::GLOBAL_TIMER_HANDLE, warn};
 
 use crate::{resource_limiter::ResourceType, ResourceGroupManager};
 
@@ -88,7 +88,7 @@ impl ResourceManagerService {
                             }});
                     }
                     Err(PdError::DataCompacted(msg)) => {
-                        error!("required revision has been compacted"; "err" => ?msg);
+                        warn!("required revision has been compacted"; "err" => ?msg);
                         self.reload_all_resource_groups().await;
                         cancel.abort();
                         continue 'outer;

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -421,7 +421,12 @@ impl<E: KvEngine> SstImporter<E> {
                 Ok(r)
             }
             Err(e) => {
-                error!(%e; "download failed"; "meta" => ?meta, "name" => name,);
+                warn!(
+                    "download failed";
+                    "meta" => ?meta,
+                    "name" => name,
+                    "err" => ?e,
+                );
                 Err(e)
             }
         }

--- a/src/server/gc_worker/gc_manager.rs
+++ b/src/server/gc_worker/gc_manager.rs
@@ -637,7 +637,10 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider + 'static, E: KvEngine> GcMan
         );
 
         if let Err(e) = res {
-            error!(?e; "gc_worker: failed to get next region information");
+            warn!(
+                "gc_worker: failed to get next region information";
+                "err" => ?e
+            );
             return (None, None);
         };
 

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -593,7 +593,13 @@ where
         }
 
         let (sink_err, recv_err) = (res.0.err(), res.1.err());
-        error!("connection aborted"; "store_id" => self.store_id, "sink_error" => ?sink_err, "receiver_err" => ?recv_err, "addr" => %self.sender.addr);
+        warn!(
+            "connection aborted";
+            "store_id" => self.store_id,
+            "sink_error" => ?sink_err,
+            "receiver_err" => ?recv_err,
+            "addr" => %self.sender.addr,
+        );
         if let Some(tx) = self.lifetime.take() {
             let should_fallback = [sink_err, recv_err]
                 .iter()
@@ -868,7 +874,7 @@ async fn start<S, R>(
 
         debug!("connecting to store"; "store_id" => back_end.store_id, "addr" => %addr);
         if !channel.wait_for_connected(backoff_duration).await {
-            error!("wait connect timeout"; "store_id" => back_end.store_id, "addr" => addr);
+            warn!("wait connect timeout"; "store_id" => back_end.store_id, "addr" => addr);
 
             // Clears pending messages to avoid consuming high memory when one node is
             // shutdown.
@@ -912,7 +918,7 @@ async fn start<S, R>(
             }
             // Err(_) should be tx is dropped
             Ok(RaftCallRes::Disconnected) | Err(_) => {
-                error!("connection abort"; "store_id" => back_end.store_id, "addr" => addr);
+                warn!("connection abort"; "store_id" => back_end.store_id, "addr" => addr);
                 REPORT_FAILURE_MSG_COUNTER
                     .with_label_values(&["unreachable", &back_end.store_id.to_string()])
                     .inc_by(1);

--- a/src/server/raft_server.rs
+++ b/src/server/raft_server.rs
@@ -425,7 +425,7 @@ where
                     }
                 },
                 // TODO: should we clean region for other errors too?
-                Err(e) => error!(?e; "bootstrap cluster"; "cluster_id" => self.cluster_id,),
+                Err(e) => warn!("bootstrap cluster"; "cluster_id" => self.cluster_id, "err" => ?e),
             }
             retry += 1;
             thread::sleep(CHECK_CLUSTER_BOOTSTRAPPED_RETRY_INTERVAL);

--- a/src/server/raftkv/raft_extension.rs
+++ b/src/server/raftkv/raft_extension.rs
@@ -95,8 +95,9 @@ where
             .router
             .report_snapshot_status(region_id, to_peer_id, status)
         {
-            error!(?e;
-                "report snapshot to peer failes";
+            warn!(
+                "report snapshot to peer fails";
+                "err" => ?e,
                 "to_peer_id" => to_peer_id,
                 "status" => ?status,
                 "region_id" => region_id,

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -194,7 +194,7 @@ impl ResponseBatchConsumer<(Option<Vec<u8>>, Statistics)> for GetCommandResponse
         );
         let task = MeasuredSingleResponse::new(id, res, measure, None);
         if self.tx.send_with(task, WakePolicy::Immediately).is_err() {
-            error!("KvService response batch commands fail");
+            warn!("KvService response batch commands fail");
         }
     }
 }
@@ -230,7 +230,7 @@ impl ResponseBatchConsumer<Option<Vec<u8>>> for GetCommandResponseConsumer {
         );
         let task = MeasuredSingleResponse::new(id, res, measure, None);
         if self.tx.send_with(task, WakePolicy::Immediately).is_err() {
-            error!("KvService response batch commands fail");
+            warn!("KvService response batch commands fail");
         }
     }
 }
@@ -289,7 +289,7 @@ fn future_batch_get_command<E: Engine, L: LockManager, F: KvFormat>(
                 );
                 let task = MeasuredSingleResponse::new(id, res, measure, None);
                 if tx.send_with(task, WakePolicy::Immediately).is_err() {
-                    error!("KvService response batch commands fail");
+                    warn!("KvService response batch commands fail");
                 }
             }
         }
@@ -345,7 +345,7 @@ fn future_batch_raw_get_command<E: Engine, L: LockManager, F: KvFormat>(
                 );
                 let task = MeasuredSingleResponse::new(id, res, measure, None);
                 if tx.send_with(task, WakePolicy::Immediately).is_err() {
-                    error!("KvService response batch commands fail");
+                    warn!("KvService response batch commands fail");
                 }
             }
         }

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -31,7 +31,7 @@ fn error_to_status(e: Error) -> RpcStatus {
 }
 
 fn on_grpc_error(tag: &'static str, e: &GrpcError) {
-    error!("{} failed: {:?}", tag, e);
+    warn!("{} failed: {:?}", tag, e);
 }
 
 fn error_to_grpc_error(tag: &'static str, e: Error) -> GrpcError {

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -821,7 +821,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
             let status = match res.await {
                 Err(e) => {
                     let msg = format!("{:?}", e);
-                    error!("dispatch raft msg from gRPC to raftstore fail"; "err" => %msg);
+                    warn!("dispatch raft msg from gRPC to raftstore fail"; "err" => %msg);
                     RpcStatus::with_message(RpcStatusCode::UNKNOWN, msg)
                 }
                 Ok(_) => RpcStatus::new(RpcStatusCode::UNKNOWN),
@@ -886,14 +886,14 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
                 Err(e) => {
                     fail_point!("on_batch_raft_stream_drop_by_err");
                     let msg = format!("{:?}", e);
-                    error!("dispatch raft msg from gRPC to raftstore fail"; "err" => %msg);
+                    warn!("dispatch raft msg from gRPC to raftstore fail"; "err" => %msg);
                     RpcStatus::with_message(RpcStatusCode::UNKNOWN, msg)
                 }
                 Ok(_) => RpcStatus::new(RpcStatusCode::UNKNOWN),
             };
             let _ = sink
                 .fail(status)
-                .map_err(|e| error!("KvService::batch_raft send response fail"; "err" => ?e))
+                .map_err(|e| warn!("KvService::batch_raft send response fail"; "err" => ?e))
                 .await;
         });
     }
@@ -1091,7 +1091,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
             }
             future::ok(())
         });
-        ctx.spawn(request_handler.unwrap_or_else(|e| error!("batch_commands error"; "err" => %e)));
+        ctx.spawn(request_handler.unwrap_or_else(|e| warn!("batch_commands error"; "err" => %e)));
 
         let grpc_thread_load = Arc::clone(&self.grpc_thread_load);
         let response_retriever = BatchReceiver::new(
@@ -1322,13 +1322,13 @@ fn response_batch_commands_request<F, T>(
             Ok(resp) => {
                 let task = MeasuredSingleResponse::new(id, resp, measure, None);
                 if let Err(e) = tx.send_with(task, WakePolicy::Immediately) {
-                    error!("KvService response batch commands fail"; "err" => ?e);
+                    warn!("KvService response batch commands fail"; "err" => ?e);
                 }
             }
             Err(server_err @ Error::ClusterIDMisMatch { .. }) => {
                 let task = MeasuredSingleResponse::new(id, T::default(), measure, Some(server_err));
                 if let Err(e) = tx.send_with(task, WakePolicy::Immediately) {
-                    error!("KvService response batch commands fail"; "err" => ?e);
+                    warn!("KvService response batch commands fail"; "err" => ?e);
                 }
             }
             _ => {}

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -559,7 +559,7 @@ impl<R: RaftExtension + 'static> Runnable for Runner<R> {
                     let result =
                         recv_snap(stream, sink, snap_mgr, raft_router, recving_count).await;
                     if let Err(e) = result {
-                        error!("failed to recv snapshot"; "err" => %e);
+                        warn!("failed to recv snapshot"; "err" => %e);
                     }
                 };
                 self.pool.spawn(task);
@@ -602,7 +602,7 @@ impl<R: RaftExtension + 'static> Runnable for Runner<R> {
                     .await;
                     recving_count.fetch_sub(1, Ordering::SeqCst);
                     if let Err(e) = result {
-                        error!("failed to recv snapshot"; "err" => %e);
+                        warn!("failed to recv snapshot"; "err" => %e);
                     }
                 };
                 self.pool.spawn(task);
@@ -645,7 +645,7 @@ impl<R: RaftExtension + 'static> Runnable for Runner<R> {
                             cb(Ok(()));
                         }
                         Err(e) => {
-                            error!("failed to send snap"; "to_addr" => addr, "region_id" => region_id, "err" => ?e);
+                            warn!("failed to send snap"; "to_addr" => addr, "region_id" => region_id, "err" => ?e);
                             cb(Err(e));
                         }
                     };

--- a/src/server/tablet_snap.rs
+++ b/src/server/tablet_snap.rs
@@ -932,7 +932,7 @@ where
                     .await;
                     recving_count.fetch_sub(1, Ordering::SeqCst);
                     if let Err(e) = result {
-                        error!("failed to recv snapshot"; "err" => %e);
+                        warn!("failed to recv snapshot"; "err" => %e);
                     }
                 });
             }
@@ -987,7 +987,7 @@ where
                             cb(Ok(()));
                         }
                         Err(e) => {
-                            error!("failed to send snap"; "to_addr" => addr, "region_id" => region_id, "err" => ?e);
+                            warn!("failed to send snap"; "to_addr" => addr, "region_id" => region_id, "err" => ?e);
                             cb(Err(e));
                         }
                     };


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
cherry-pick https://github.com/tikv/tikv/pull/18746 to raftstore-proxy
```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
